### PR TITLE
Mapping for errors

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -9,7 +9,6 @@ package libvirt
 import "C"
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 	"unsafe"
@@ -77,7 +76,7 @@ func (dest *VirTypedParameters) loadFromCPtr(params C.virTypedParameterPtr, nPar
 
 func (d *VirDomain) Free() error {
 	if result := C.virDomainFree(d.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -85,7 +84,7 @@ func (d *VirDomain) Free() error {
 func (d *VirDomain) Create() error {
 	result := C.virDomainCreate(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -93,7 +92,7 @@ func (d *VirDomain) Create() error {
 func (d *VirDomain) Destroy() error {
 	result := C.virDomainDestroy(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -101,7 +100,7 @@ func (d *VirDomain) Destroy() error {
 func (d *VirDomain) Shutdown() error {
 	result := C.virDomainShutdown(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -109,7 +108,7 @@ func (d *VirDomain) Shutdown() error {
 func (d *VirDomain) Reboot(flags uint) error {
 	result := C.virDomainReboot(d.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -117,7 +116,7 @@ func (d *VirDomain) Reboot(flags uint) error {
 func (d *VirDomain) IsActive() (bool, error) {
 	result := C.virDomainIsActive(d.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -135,7 +134,7 @@ func (d *VirDomain) SetAutostart(autostart bool) error {
 	}
 	result := C.virDomainSetAutostart(d.ptr, cAutostart)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -144,7 +143,7 @@ func (d *VirDomain) GetAutostart() (bool, error) {
 	var out C.int
 	result := C.virDomainGetAutostart(d.ptr, (*C.int)(unsafe.Pointer(&out)))
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	switch out {
 	case 1:
@@ -161,7 +160,7 @@ func (d *VirDomain) GetBlockInfo(disk string, flag uint) (VirDomainBlockInfo, er
 	defer C.free(unsafe.Pointer(cDisk))
 	result := C.virDomainGetBlockInfo(d.ptr, cDisk, (*C.virDomainBlockInfo)(unsafe.Pointer(&ptr)), C.uint(flag))
 	if result == -1 {
-		return bi, errors.New(GetLastError())
+		return bi, GetLastError()
 	}
 	bi.ptr = ptr
 	return bi, nil
@@ -182,7 +181,7 @@ func (b *VirDomainBlockInfo) Physical() uint64 {
 func (d *VirDomain) GetName() (string, error) {
 	name := C.virDomainGetName(d.ptr)
 	if name == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(name), nil
 }
@@ -195,7 +194,7 @@ func (d *VirDomain) GetState() ([]int, error) {
 		(*C.int)(unsafe.Pointer(&cReason)),
 		0)
 	if int(result) == -1 {
-		return []int{}, errors.New(GetLastError())
+		return []int{}, GetLastError()
 	}
 	return []int{int(cState), int(cReason)}, nil
 }
@@ -205,7 +204,7 @@ func (d *VirDomain) GetUUID() ([]byte, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virDomainGetUUID(d.ptr, (*C.uchar)(cuidPtr))
 	if result != 0 {
-		return []byte{}, errors.New(GetLastError())
+		return []byte{}, GetLastError()
 	}
 	return C.GoBytes(cuidPtr, C.VIR_UUID_BUFLEN), nil
 }
@@ -215,7 +214,7 @@ func (d *VirDomain) GetUUIDString() (string, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virDomainGetUUIDString(d.ptr, (*C.char)(cuidPtr))
 	if result != 0 {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString((*C.char)(cuidPtr)), nil
 }
@@ -225,7 +224,7 @@ func (d *VirDomain) GetInfo() (VirDomainInfo, error) {
 	var ptr C.virDomainInfo
 	result := C.virDomainGetInfo(d.ptr, (*C.virDomainInfo)(unsafe.Pointer(&ptr)))
 	if result == -1 {
-		return di, errors.New(GetLastError())
+		return di, GetLastError()
 	}
 	di.ptr = ptr
 	return di, nil
@@ -234,7 +233,7 @@ func (d *VirDomain) GetInfo() (VirDomainInfo, error) {
 func (d *VirDomain) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virDomainGetXMLDesc(d.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -277,7 +276,7 @@ func (d *VirDomain) GetCPUStats(params *VirTypedParameters, nParams int, startCp
 
 	result := int(C.virDomainGetCPUStats(d.ptr, (C.virTypedParameterPtr)(cParams), C.uint(nParams), C.int(startCpu), C.uint(nCpus), C.uint(flags)))
 	if result == -1 {
-		return result, errors.New(GetLastError())
+		return result, GetLastError()
 	}
 
 	if cParamsLen > 0 {
@@ -300,7 +299,7 @@ func (d *VirDomain) GetInterfaceParameters(device string, params *VirTypedParame
 
 	result := int(C.virDomainGetInterfaceParameters(d.ptr, C.CString(device), (C.virTypedParameterPtr)(cParams), (*C.int)(unsafe.Pointer(nParams)), C.uint(flags)))
 	if result == -1 {
-		return result, errors.New(GetLastError())
+		return result, GetLastError()
 	}
 
 	if params != nil && *nParams > 0 {
@@ -319,7 +318,7 @@ func (d *VirDomain) GetMetadata(tipus int, uri string, flags uint32) (string, er
 
 	result := C.virDomainGetMetadata(d.ptr, C.int(tipus), cUri, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 
 	}
 	defer C.free(unsafe.Pointer(result))
@@ -342,7 +341,7 @@ func (d *VirDomain) SetMetadata(metaDataType int, metaDataCont, uriKey, uri stri
 	}
 	result := C.virDomainSetMetadata(d.ptr, C.int(metaDataType), cMetaDataCont, cUriKey, cUri, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -350,7 +349,7 @@ func (d *VirDomain) SetMetadata(metaDataType int, metaDataCont, uriKey, uri stri
 func (d *VirDomain) Undefine() error {
 	result := C.virDomainUndefine(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -358,7 +357,7 @@ func (d *VirDomain) Undefine() error {
 func (d *VirDomain) SetMaxMemory(memory uint) error {
 	result := C.virDomainSetMaxMemory(d.ptr, C.ulong(memory))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -366,7 +365,7 @@ func (d *VirDomain) SetMaxMemory(memory uint) error {
 func (d *VirDomain) SetMemory(memory uint64) error {
 	result := C.virDomainSetMemory(d.ptr, C.ulong(memory))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -374,7 +373,7 @@ func (d *VirDomain) SetMemory(memory uint64) error {
 func (d *VirDomain) SetMemoryFlags(memory uint64, flags uint32) error {
 	result := C.virDomainSetMemoryFlags(d.ptr, C.ulong(memory), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -382,7 +381,7 @@ func (d *VirDomain) SetMemoryFlags(memory uint64, flags uint32) error {
 func (d *VirDomain) SetMemoryStatsPeriod(period int, flags uint) error {
 	result := C.virDomainSetMemoryStatsPeriod(d.ptr, C.int(period), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -390,7 +389,7 @@ func (d *VirDomain) SetMemoryStatsPeriod(period int, flags uint) error {
 func (d *VirDomain) SetVcpus(vcpu uint) error {
 	result := C.virDomainSetVcpus(d.ptr, C.uint(vcpu))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -398,7 +397,7 @@ func (d *VirDomain) SetVcpus(vcpu uint) error {
 func (d *VirDomain) SetVcpusFlags(vcpu uint, flags uint) error {
 	result := C.virDomainSetVcpusFlags(d.ptr, C.uint(vcpu), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -406,7 +405,7 @@ func (d *VirDomain) SetVcpusFlags(vcpu uint, flags uint) error {
 func (d *VirDomain) Suspend() error {
 	result := C.virDomainSuspend(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -414,7 +413,7 @@ func (d *VirDomain) Suspend() error {
 func (d *VirDomain) Resume() error {
 	result := C.virDomainResume(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -422,7 +421,7 @@ func (d *VirDomain) Resume() error {
 func (d *VirDomain) AbortJob() error {
 	result := C.virDomainAbortJob(d.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -430,7 +429,7 @@ func (d *VirDomain) AbortJob() error {
 func (d *VirDomain) DestroyFlags(flags uint) error {
 	result := C.virDomainDestroyFlags(d.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -438,7 +437,7 @@ func (d *VirDomain) DestroyFlags(flags uint) error {
 func (d *VirDomain) ShutdownFlags(flags uint) error {
 	result := C.virDomainShutdownFlags(d.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -448,7 +447,7 @@ func (d *VirDomain) AttachDevice(xml string) error {
 	defer C.free(unsafe.Pointer(cXml))
 	result := C.virDomainAttachDevice(d.ptr, cXml)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -458,7 +457,7 @@ func (d *VirDomain) AttachDeviceFlags(xml string, flags uint) error {
 	defer C.free(unsafe.Pointer(cXml))
 	result := C.virDomainAttachDeviceFlags(d.ptr, cXml, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -468,7 +467,7 @@ func (d *VirDomain) DetachDevice(xml string) error {
 	defer C.free(unsafe.Pointer(cXml))
 	result := C.virDomainDetachDevice(d.ptr, cXml)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -478,7 +477,7 @@ func (d *VirDomain) DetachDeviceFlags(xml string, flags uint) error {
 	defer C.free(unsafe.Pointer(cXml))
 	result := C.virDomainDetachDeviceFlags(d.ptr, cXml, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -486,7 +485,7 @@ func (d *VirDomain) DetachDeviceFlags(xml string, flags uint) error {
 func (d *VirDomain) Screenshot(stream *VirStream, screen, flags uint) (string, error) {
 	cType := C.virDomainScreenshot(d.ptr, stream.ptr, C.uint(screen), C.uint(flags))
 	if cType == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	defer C.free(unsafe.Pointer(cType))
 
@@ -497,7 +496,7 @@ func (d *VirDomain) Screenshot(stream *VirStream, screen, flags uint) (string, e
 func (d *VirDomain) SendKey(codeset, holdtime uint, keycodes []uint, flags uint) error {
 	result := C.virDomainSendKey(d.ptr, C.uint(codeset), C.uint(holdtime), (*C.uint)(unsafe.Pointer(&keycodes[0])), C.int(len(keycodes)), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 
 	return nil
@@ -519,7 +518,7 @@ func (d *VirDomain) BlockStatsFlags(disk string, params *VirTypedParameters, nPa
 
 	result := int(C.virDomainBlockStatsFlags(d.ptr, cDisk, (C.virTypedParameterPtr)(cParams), &cParamsLen, C.uint(flags)))
 	if result == -1 {
-		return result, errors.New(GetLastError())
+		return result, GetLastError()
 	}
 
 	if cParamsLen > 0 && params != nil {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,490 @@
+package libvirt
+
+/*
+#cgo LDFLAGS: -lvirt -ldl
+#include <libvirt/libvirt.h>
+#include <libvirt/virterror.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import "fmt"
+
+// virErrorLevel
+const (
+	VIR_ERR_NONE    = C.VIR_ERR_NONE
+	VIR_ERR_WARNING = C.VIR_ERR_WARNING
+	VIR_ERR_ERROR   = C.VIR_ERR_ERROR
+)
+
+// virErrorNumber
+const (
+	VIR_ERR_OK = C.VIR_ERR_OK
+
+	// internal error
+	VIR_ERR_INTERNAL_ERROR = C.VIR_ERR_INTERNAL_ERROR
+
+	// memory allocation failure
+	VIR_ERR_NO_MEMORY = C.VIR_ERR_NO_MEMORY
+
+	// no support for this function
+	VIR_ERR_NO_SUPPORT = C.VIR_ERR_NO_SUPPORT
+
+	// could not resolve hostname
+	VIR_ERR_UNKNOWN_HOST = C.VIR_ERR_UNKNOWN_HOST
+
+	// can't connect to hypervisor
+	VIR_ERR_NO_CONNECT = C.VIR_ERR_NO_CONNECT
+
+	// invalid connection object
+	VIR_ERR_INVALID_CONN = C.VIR_ERR_INVALID_CONN
+
+	// invalid domain object
+	VIR_ERR_INVALID_DOMAIN = C.VIR_ERR_INVALID_DOMAIN
+
+	// invalid function argument
+	VIR_ERR_INVALID_ARG = C.VIR_ERR_INVALID_ARG
+
+	// a command to hypervisor failed
+	VIR_ERR_OPERATION_FAILED = C.VIR_ERR_OPERATION_FAILED
+
+	// a HTTP GET command to failed
+	VIR_ERR_GET_FAILED = C.VIR_ERR_GET_FAILED
+
+	// a HTTP POST command to failed
+	VIR_ERR_POST_FAILED = C.VIR_ERR_POST_FAILED
+
+	// unexpected HTTP error code
+	VIR_ERR_HTTP_ERROR = C.VIR_ERR_HTTP_ERROR
+
+	// failure to serialize an S-Expr
+	VIR_ERR_SEXPR_SERIAL = C.VIR_ERR_SEXPR_SERIAL
+
+	// could not open Xen hypervisor control
+	VIR_ERR_NO_XEN = C.VIR_ERR_NO_XEN
+
+	// failure doing an hypervisor call
+	VIR_ERR_XEN_CALL = C.VIR_ERR_XEN_CALL
+
+	// unknown OS type
+	VIR_ERR_OS_TYPE = C.VIR_ERR_OS_TYPE
+
+	// missing kernel information
+	VIR_ERR_NO_KERNEL = C.VIR_ERR_NO_KERNEL
+
+	// missing root device information
+	VIR_ERR_NO_ROOT = C.VIR_ERR_NO_ROOT
+
+	// missing source device information
+	VIR_ERR_NO_SOURCE = C.VIR_ERR_NO_SOURCE
+
+	// missing target device information
+	VIR_ERR_NO_TARGET = C.VIR_ERR_NO_TARGET
+
+	// missing domain name information
+	VIR_ERR_NO_NAME = C.VIR_ERR_NO_NAME
+
+	// missing domain OS information
+	VIR_ERR_NO_OS = C.VIR_ERR_NO_OS
+
+	// missing domain devices information
+	VIR_ERR_NO_DEVICE = C.VIR_ERR_NO_DEVICE
+
+	// could not open Xen Store control
+	VIR_ERR_NO_XENSTORE = C.VIR_ERR_NO_XENSTORE
+
+	// too many drivers registered
+	VIR_ERR_DRIVER_FULL = C.VIR_ERR_DRIVER_FULL
+
+	// not supported by the drivers (DEPRECATED)
+	VIR_ERR_CALL_FAILED = C.VIR_ERR_CALL_FAILED
+
+	// an XML description is not well formed or broken
+	VIR_ERR_XML_ERROR = C.VIR_ERR_XML_ERROR
+
+	// the domain already exist
+	VIR_ERR_DOM_EXIST = C.VIR_ERR_DOM_EXIST
+
+	// operation forbidden on read-only connections
+	VIR_ERR_OPERATION_DENIED = C.VIR_ERR_OPERATION_DENIED
+
+	// failed to open a conf file
+	VIR_ERR_OPEN_FAILED = C.VIR_ERR_OPEN_FAILED
+
+	// failed to read a conf file
+	VIR_ERR_READ_FAILED = C.VIR_ERR_READ_FAILED
+
+	// failed to parse a conf file
+	VIR_ERR_PARSE_FAILED = C.VIR_ERR_PARSE_FAILED
+
+	// failed to parse the syntax of a conf file
+	VIR_ERR_CONF_SYNTAX = C.VIR_ERR_CONF_SYNTAX
+
+	// failed to write a conf file
+	VIR_ERR_WRITE_FAILED = C.VIR_ERR_WRITE_FAILED
+
+	// detail of an XML error
+	VIR_ERR_XML_DETAIL = C.VIR_ERR_XML_DETAIL
+
+	// invalid network object
+	VIR_ERR_INVALID_NETWORK = C.VIR_ERR_INVALID_NETWORK
+
+	// the network already exist
+	VIR_ERR_NETWORK_EXIST = C.VIR_ERR_NETWORK_EXIST
+
+	// general system call failure
+	VIR_ERR_SYSTEM_ERROR = C.VIR_ERR_SYSTEM_ERROR
+
+	// some sort of RPC error
+	VIR_ERR_RPC = C.VIR_ERR_RPC
+
+	// error from a GNUTLS call
+	VIR_ERR_GNUTLS_ERROR = C.VIR_ERR_GNUTLS_ERROR
+
+	// failed to start network
+	VIR_WAR_NO_NETWORK = C.VIR_WAR_NO_NETWORK
+
+	// domain not found or unexpectedly disappeared
+	VIR_ERR_NO_DOMAIN = C.VIR_ERR_NO_DOMAIN
+
+	// network not found
+	VIR_ERR_NO_NETWORK = C.VIR_ERR_NO_NETWORK
+
+	// invalid MAC address
+	VIR_ERR_INVALID_MAC = C.VIR_ERR_INVALID_MAC
+
+	// authentication failed
+	VIR_ERR_AUTH_FAILED = C.VIR_ERR_AUTH_FAILED
+
+	// invalid storage pool object
+	VIR_ERR_INVALID_STORAGE_POOL = C.VIR_ERR_INVALID_STORAGE_POOL
+
+	// invalid storage vol object
+	VIR_ERR_INVALID_STORAGE_VOL = C.VIR_ERR_INVALID_STORAGE_VOL
+
+	// failed to start storage
+	VIR_WAR_NO_STORAGE = C.VIR_WAR_NO_STORAGE
+
+	// storage pool not found
+	VIR_ERR_NO_STORAGE_POOL = C.VIR_ERR_NO_STORAGE_POOL
+
+	// storage volume not found
+	VIR_ERR_NO_STORAGE_VOL = C.VIR_ERR_NO_STORAGE_VOL
+
+	// failed to start node driver
+	VIR_WAR_NO_NODE = C.VIR_WAR_NO_NODE
+
+	// invalid node device object
+	VIR_ERR_INVALID_NODE_DEVICE = C.VIR_ERR_INVALID_NODE_DEVICE
+
+	// node device not found
+	VIR_ERR_NO_NODE_DEVICE = C.VIR_ERR_NO_NODE_DEVICE
+
+	// security model not found
+	VIR_ERR_NO_SECURITY_MODEL = C.VIR_ERR_NO_SECURITY_MODEL
+
+	// operation is not applicable at this time
+	VIR_ERR_OPERATION_INVALID = C.VIR_ERR_OPERATION_INVALID
+
+	// failed to start interface driver
+	VIR_WAR_NO_INTERFACE = C.VIR_WAR_NO_INTERFACE
+
+	// interface driver not running
+	VIR_ERR_NO_INTERFACE = C.VIR_ERR_NO_INTERFACE
+
+	// invalid interface object
+	VIR_ERR_INVALID_INTERFACE = C.VIR_ERR_INVALID_INTERFACE
+
+	// more than one matching interface found
+	VIR_ERR_MULTIPLE_INTERFACES = C.VIR_ERR_MULTIPLE_INTERFACES
+
+	// failed to start nwfilter driver
+	VIR_WAR_NO_NWFILTER = C.VIR_WAR_NO_NWFILTER
+
+	// invalid nwfilter object
+	VIR_ERR_INVALID_NWFILTER = C.VIR_ERR_INVALID_NWFILTER
+
+	// nw filter pool not found
+	VIR_ERR_NO_NWFILTER = C.VIR_ERR_NO_NWFILTER
+
+	// nw filter pool not found
+	VIR_ERR_BUILD_FIREWALL = C.VIR_ERR_BUILD_FIREWALL
+
+	// failed to start secret storage
+	VIR_WAR_NO_SECRET = C.VIR_WAR_NO_SECRET
+
+	// invalid secret
+	VIR_ERR_INVALID_SECRET = C.VIR_ERR_INVALID_SECRET
+
+	// secret not found
+	VIR_ERR_NO_SECRET = C.VIR_ERR_NO_SECRET
+
+	// unsupported configuration construct
+	VIR_ERR_CONFIG_UNSUPPORTED = C.VIR_ERR_CONFIG_UNSUPPORTED
+
+	// timeout occurred during operation
+	VIR_ERR_OPERATION_TIMEOUT = C.VIR_ERR_OPERATION_TIMEOUT
+
+	// a migration worked, but making the VM persist on the dest host failed
+	VIR_ERR_MIGRATE_PERSIST_FAILED = C.VIR_ERR_MIGRATE_PERSIST_FAILED
+
+	// a synchronous hook script failed
+	VIR_ERR_HOOK_SCRIPT_FAILED = C.VIR_ERR_HOOK_SCRIPT_FAILED
+
+	// invalid domain snapshot
+	VIR_ERR_INVALID_DOMAIN_SNAPSHOT = C.VIR_ERR_INVALID_DOMAIN_SNAPSHOT
+
+	// domain snapshot not found
+	VIR_ERR_NO_DOMAIN_SNAPSHOT = C.VIR_ERR_NO_DOMAIN_SNAPSHOT
+
+	// stream pointer not valid
+	VIR_ERR_INVALID_STREAM = C.VIR_ERR_INVALID_STREAM
+
+	// valid API use but unsupported by the given driver
+	VIR_ERR_ARGUMENT_UNSUPPORTED = C.VIR_ERR_ARGUMENT_UNSUPPORTED
+
+	// storage pool probe failed
+	VIR_ERR_STORAGE_PROBE_FAILED = C.VIR_ERR_STORAGE_PROBE_FAILED
+
+	// storage pool already built
+	VIR_ERR_STORAGE_POOL_BUILT = C.VIR_ERR_STORAGE_POOL_BUILT
+
+	// force was not requested for a risky domain snapshot revert
+	VIR_ERR_SNAPSHOT_REVERT_RISKY = C.VIR_ERR_SNAPSHOT_REVERT_RISKY
+
+	// operation on a domain was canceled/aborted by user
+	VIR_ERR_OPERATION_ABORTED = C.VIR_ERR_OPERATION_ABORTED
+
+	// authentication cancelled
+	VIR_ERR_AUTH_CANCELLED = C.VIR_ERR_AUTH_CANCELLED
+
+	// The metadata is not present
+	VIR_ERR_NO_DOMAIN_METADATA = C.VIR_ERR_NO_DOMAIN_METADATA
+
+	// Migration is not safe
+	VIR_ERR_MIGRATE_UNSAFE = C.VIR_ERR_MIGRATE_UNSAFE
+
+	// integer overflow
+	VIR_ERR_OVERFLOW = C.VIR_ERR_OVERFLOW
+
+	// action prevented by block copy job
+	VIR_ERR_BLOCK_COPY_ACTIVE = C.VIR_ERR_BLOCK_COPY_ACTIVE
+
+	// The requested operation is not supported
+	VIR_ERR_OPERATION_UNSUPPORTED = C.VIR_ERR_OPERATION_UNSUPPORTED
+
+	// error in ssh transport driver
+	VIR_ERR_SSH = C.VIR_ERR_SSH
+
+	// guest agent is unresponsive, not running or not usable
+	VIR_ERR_AGENT_UNRESPONSIVE = C.VIR_ERR_AGENT_UNRESPONSIVE
+
+	// resource is already in use
+	VIR_ERR_RESOURCE_BUSY = C.VIR_ERR_RESOURCE_BUSY
+
+	// operation on the object/resource was denied
+	VIR_ERR_ACCESS_DENIED = C.VIR_ERR_ACCESS_DENIED
+
+	// error from a dbus service
+	VIR_ERR_DBUS_SERVICE = C.VIR_ERR_DBUS_SERVICE
+
+	// the storage vol already exists
+	VIR_ERR_STORAGE_VOL_EXIST = C.VIR_ERR_STORAGE_VOL_EXIST
+
+	// given CPU is incompatible with host CPU
+	VIR_ERR_CPU_INCOMPATIBLE = C.VIR_ERR_CPU_INCOMPATIBLE
+)
+
+// virErrorDomain
+const (
+	VIR_FROM_NONE = C.VIR_FROM_NONE
+
+	// Error at Xen hypervisor layer
+	VIR_FROM_XEN = C.VIR_FROM_XEN
+
+	// Error at connection with xend daemon
+	VIR_FROM_XEND = C.VIR_FROM_XEND
+
+	// Error at connection with xen store
+	VIR_FROM_XENSTORE = C.VIR_FROM_XENSTORE
+
+	// Error in the S-Expression code
+	VIR_FROM_SEXPR = C.VIR_FROM_SEXPR
+
+	// Error in the XML code
+	VIR_FROM_XML = C.VIR_FROM_XML
+
+	// Error when operating on a domain
+	VIR_FROM_DOM = C.VIR_FROM_DOM
+
+	// Error in the XML-RPC code
+	VIR_FROM_RPC = C.VIR_FROM_RPC
+
+	// Error in the proxy code; unused since 0.8.6
+	VIR_FROM_PROXY = C.VIR_FROM_PROXY
+
+	// Error in the configuration file handling
+	VIR_FROM_CONF = C.VIR_FROM_CONF
+
+	// Error at the QEMU daemon
+	VIR_FROM_QEMU = C.VIR_FROM_QEMU
+
+	// Error when operating on a network
+	VIR_FROM_NET = C.VIR_FROM_NET
+
+	// Error from test driver
+	VIR_FROM_TEST = C.VIR_FROM_TEST
+
+	// Error from remote driver
+	VIR_FROM_REMOTE = C.VIR_FROM_REMOTE
+
+	// Error from OpenVZ driver
+	VIR_FROM_OPENVZ = C.VIR_FROM_OPENVZ
+
+	// Error at Xen XM layer
+	VIR_FROM_XENXM = C.VIR_FROM_XENXM
+
+	// Error in the Linux Stats code
+	VIR_FROM_STATS_LINUX = C.VIR_FROM_STATS_LINUX
+
+	// Error from Linux Container driver
+	VIR_FROM_LXC = C.VIR_FROM_LXC
+
+	// Error from storage driver
+	VIR_FROM_STORAGE = C.VIR_FROM_STORAGE
+
+	// Error from network config
+	VIR_FROM_NETWORK = C.VIR_FROM_NETWORK
+
+	// Error from domain config
+	VIR_FROM_DOMAIN = C.VIR_FROM_DOMAIN
+
+	// Error at the UML driver
+	VIR_FROM_UML = C.VIR_FROM_UML
+
+	// Error from node device monitor
+	VIR_FROM_NODEDEV = C.VIR_FROM_NODEDEV
+
+	// Error from xen inotify layer
+	VIR_FROM_XEN_INOTIFY = C.VIR_FROM_XEN_INOTIFY
+
+	// Error from security framework
+	VIR_FROM_SECURITY = C.VIR_FROM_SECURITY
+
+	// Error from VirtualBox driver
+	VIR_FROM_VBOX = C.VIR_FROM_VBOX
+
+	// Error when operating on an interface
+	VIR_FROM_INTERFACE = C.VIR_FROM_INTERFACE
+
+	// The OpenNebula driver no longer exists. Retained for ABI/API compat only
+	VIR_FROM_ONE = C.VIR_FROM_ONE
+
+	// Error from ESX driver
+	VIR_FROM_ESX = C.VIR_FROM_ESX
+
+	// Error from IBM power hypervisor
+	VIR_FROM_PHYP = C.VIR_FROM_PHYP
+
+	// Error from secret storage
+	VIR_FROM_SECRET = C.VIR_FROM_SECRET
+
+	// Error from CPU driver
+	VIR_FROM_CPU = C.VIR_FROM_CPU
+
+	// Error from XenAPI
+	VIR_FROM_XENAPI = C.VIR_FROM_XENAPI
+
+	// Error from network filter driver
+	VIR_FROM_NWFILTER = C.VIR_FROM_NWFILTER
+
+	// Error from Synchronous hooks
+	VIR_FROM_HOOK = C.VIR_FROM_HOOK
+
+	// Error from domain snapshot
+	VIR_FROM_DOMAIN_SNAPSHOT = C.VIR_FROM_DOMAIN_SNAPSHOT
+
+	// Error from auditing subsystem
+	VIR_FROM_AUDIT = C.VIR_FROM_AUDIT
+
+	// Error from sysinfo/SMBIOS
+	VIR_FROM_SYSINFO = C.VIR_FROM_SYSINFO
+
+	// Error from I/O streams
+	VIR_FROM_STREAMS = C.VIR_FROM_STREAMS
+
+	// Error from VMware driver
+	VIR_FROM_VMWARE = C.VIR_FROM_VMWARE
+
+	// Error from event loop impl
+	VIR_FROM_EVENT = C.VIR_FROM_EVENT
+
+	// Error from libxenlight driver
+	VIR_FROM_LIBXL = C.VIR_FROM_LIBXL
+
+	// Error from lock manager
+	VIR_FROM_LOCKING = C.VIR_FROM_LOCKING
+
+	// Error from Hyper-V driver
+	VIR_FROM_HYPERV = C.VIR_FROM_HYPERV
+
+	// Error from capabilities
+	VIR_FROM_CAPABILITIES = C.VIR_FROM_CAPABILITIES
+
+	// Error from URI handling
+	VIR_FROM_URI = C.VIR_FROM_URI
+
+	// Error from auth handling
+	VIR_FROM_AUTH = C.VIR_FROM_AUTH
+
+	// Error from DBus
+	VIR_FROM_DBUS = C.VIR_FROM_DBUS
+
+	// Error from Parallels
+	VIR_FROM_PARALLELS = C.VIR_FROM_PARALLELS
+
+	// Error from Device
+	VIR_FROM_DEVICE = C.VIR_FROM_DEVICE
+
+	// Error from libssh2 connection transport
+	VIR_FROM_SSH = C.VIR_FROM_SSH
+
+	// Error from lockspace
+	VIR_FROM_LOCKSPACE = C.VIR_FROM_LOCKSPACE
+
+	// Error from initctl device communication
+	VIR_FROM_INITCTL = C.VIR_FROM_INITCTL
+
+	// Error from identity code
+	VIR_FROM_IDENTITY = C.VIR_FROM_IDENTITY
+
+	// Error from cgroups
+	VIR_FROM_CGROUP = C.VIR_FROM_CGROUP
+
+	// Error from access control manager
+	VIR_FROM_ACCESS = C.VIR_FROM_ACCESS
+
+	// Error from systemd code
+	VIR_FROM_SYSTEMD = C.VIR_FROM_SYSTEMD
+
+	// Error from bhyve driver
+	VIR_FROM_BHYVE = C.VIR_FROM_BHYVE
+
+	// Error from crypto code
+	VIR_FROM_CRYPTO = C.VIR_FROM_CRYPTO
+
+	// Error from firewall
+	VIR_FROM_FIREWALL = C.VIR_FROM_FIREWALL
+)
+
+type VirError struct {
+	Code    int32
+	Domain  int32
+	Message string
+	Level   int
+}
+
+func (err *VirError) Error() string {
+	return fmt.Sprintf("[Code-%d] [Domain-%d] %s",
+		err.Code, err.Domain, err.Message)
+}

--- a/interface.go
+++ b/interface.go
@@ -20,7 +20,7 @@ type VirInterface struct {
 func (n *VirInterface) Create(flags uint32) error {
 	result := C.virInterfaceCreate(n.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -28,7 +28,7 @@ func (n *VirInterface) Create(flags uint32) error {
 func (n *VirInterface) Destroy(flags uint32) error {
 	result := C.virInterfaceDestroy(n.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -36,7 +36,7 @@ func (n *VirInterface) Destroy(flags uint32) error {
 func (n *VirInterface) IsActive() (bool, error) {
 	result := C.virInterfaceIsActive(n.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -47,7 +47,7 @@ func (n *VirInterface) IsActive() (bool, error) {
 func (n *VirInterface) GetMACString() (string, error) {
 	result := C.virInterfaceGetMACString(n.ptr)
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	mac := C.GoString(result)
 	return mac, nil
@@ -56,7 +56,7 @@ func (n *VirInterface) GetMACString() (string, error) {
 func (n *VirInterface) GetName() (string, error) {
 	result := C.virInterfaceGetName(n.ptr)
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	name := C.GoString(result)
 	return name, nil
@@ -65,7 +65,7 @@ func (n *VirInterface) GetName() (string, error) {
 func (n *VirInterface) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virInterfaceGetXMLDesc(n.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -75,14 +75,14 @@ func (n *VirInterface) GetXMLDesc(flags uint32) (string, error) {
 func (n *VirInterface) Undefine() error {
 	result := C.virInterfaceUndefine(n.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
 
 func (n *VirInterface) Free() error {
 	if result := C.virInterfaceFree(n.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }

--- a/libvirt.go
+++ b/libvirt.go
@@ -1,8 +1,6 @@
 package libvirt
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"unsafe"
@@ -25,7 +23,7 @@ func NewVirConnection(uri string) (VirConnection, error) {
 	defer C.free(unsafe.Pointer(cUri))
 	ptr := C.virConnectOpen(cUri)
 	if ptr == nil {
-		return VirConnection{}, errors.New(GetLastError())
+		return VirConnection{}, GetLastError()
 	}
 	obj := VirConnection{ptr: ptr}
 	return obj, nil
@@ -36,24 +34,29 @@ func NewVirConnectionReadOnly(uri string) (VirConnection, error) {
 	defer C.free(unsafe.Pointer(cUri))
 	ptr := C.virConnectOpenReadOnly(cUri)
 	if ptr == nil {
-		return VirConnection{}, errors.New(GetLastError())
+		return VirConnection{}, GetLastError()
 	}
 	obj := VirConnection{ptr: ptr}
 	return obj, nil
 }
 
-func GetLastError() string {
+func GetLastError() VirError {
 	err := C.virGetLastError()
-	errMsg := fmt.Sprintf("[Code-%d] [Domain-%d] %s",
-		err.code, err.domain, C.GoString(err.message))
+	virErr := new(VirError)
+
+	virErr.Code = int32(err.code)
+	virErr.Domain = int32(err.domain)
+	virErr.Message = C.GoString(err.message)
+	virErr.Level = int32(err.level)
+
 	C.virResetError(err)
-	return errMsg
+	return virErr
 }
 
 func (c *VirConnection) CloseConnection() (int, error) {
 	result := int(C.virConnectClose(c.ptr))
 	if result == -1 {
-		return result, errors.New(GetLastError())
+		return result, GetLastError()
 	}
 	return result, nil
 }
@@ -73,7 +76,7 @@ func (c *VirConnection) UnrefAndCloseConnection() error {
 func (c *VirConnection) GetCapabilities() (string, error) {
 	str := C.virConnectGetCapabilities(c.ptr)
 	if str == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	capabilities := C.GoString(str)
 	C.free(unsafe.Pointer(str))
@@ -85,7 +88,7 @@ func (c *VirConnection) GetNodeInfo() (VirNodeInfo, error) {
 	var ptr C.virNodeInfo
 	result := C.virNodeGetInfo(c.ptr, (*C.virNodeInfo)(unsafe.Pointer(&ptr)))
 	if result == -1 {
-		return ni, errors.New(GetLastError())
+		return ni, GetLastError()
 	}
 	ni.ptr = ptr
 	return ni, nil
@@ -94,7 +97,7 @@ func (c *VirConnection) GetNodeInfo() (VirNodeInfo, error) {
 func (c *VirConnection) GetHostname() (string, error) {
 	str := C.virConnectGetHostname(c.ptr)
 	if str == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	hostname := C.GoString(str)
 	C.free(unsafe.Pointer(str))
@@ -104,7 +107,7 @@ func (c *VirConnection) GetHostname() (string, error) {
 func (c *VirConnection) GetLibVersion() (uint32, error) {
 	var version C.ulong
 	if err := C.virConnectGetLibVersion(c.ptr, &version); err < 0 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return uint32(version), nil
 }
@@ -112,7 +115,7 @@ func (c *VirConnection) GetLibVersion() (uint32, error) {
 func (c *VirConnection) GetType() (string, error) {
 	str := C.virConnectGetType(c.ptr)
 	if str == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	hypDriver := C.GoString(str)
 	return hypDriver, nil
@@ -121,7 +124,7 @@ func (c *VirConnection) GetType() (string, error) {
 func (c *VirConnection) IsAlive() (bool, error) {
 	result := C.virConnectIsAlive(c.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -132,7 +135,7 @@ func (c *VirConnection) IsAlive() (bool, error) {
 func (c *VirConnection) IsEncrypted() (bool, error) {
 	result := C.virConnectIsEncrypted(c.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -143,7 +146,7 @@ func (c *VirConnection) IsEncrypted() (bool, error) {
 func (c *VirConnection) IsSecure() (bool, error) {
 	result := C.virConnectIsSecure(c.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -159,7 +162,7 @@ func (c *VirConnection) ListDefinedDomains() ([]string, error) {
 		(**C.char)(namesPtr),
 		1024)
 	if numDomains == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numDomains)
 	for k := 0; k < int(numDomains); k++ {
@@ -174,7 +177,7 @@ func (c *VirConnection) ListDomains() ([]uint32, error) {
 	cDomainsPointer := unsafe.Pointer(&cDomainsIds)
 	numDomains := C.virConnectListDomains(c.ptr, (*C.int)(cDomainsPointer), 512)
 	if numDomains == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 
 	return cDomainsIds[:numDomains], nil
@@ -189,7 +192,7 @@ func (c *VirConnection) ListInterfaces() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxIfaces)
 	if numIfaces == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numIfaces)
 	for k := 0; k < int(numIfaces); k++ {
@@ -208,7 +211,7 @@ func (c *VirConnection) ListNetworks() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxNets)
 	if numNetworks == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numNetworks)
 	for k := 0; k < int(numNetworks); k++ {
@@ -227,7 +230,7 @@ func (c *VirConnection) ListStoragePools() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxPools)
 	if numStoragePools == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numStoragePools)
 	for k := 0; k < int(numStoragePools); k++ {
@@ -240,7 +243,7 @@ func (c *VirConnection) ListStoragePools() ([]string, error) {
 func (c *VirConnection) LookupDomainById(id uint32) (VirDomain, error) {
 	ptr := C.virDomainLookupByID(c.ptr, C.int(id))
 	if ptr == nil {
-		return VirDomain{}, errors.New(GetLastError())
+		return VirDomain{}, GetLastError()
 	}
 	return VirDomain{ptr: ptr}, nil
 }
@@ -250,7 +253,7 @@ func (c *VirConnection) LookupDomainByName(id string) (VirDomain, error) {
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virDomainLookupByName(c.ptr, cName)
 	if ptr == nil {
-		return VirDomain{}, errors.New(GetLastError())
+		return VirDomain{}, GetLastError()
 	}
 	return VirDomain{ptr: ptr}, nil
 }
@@ -268,7 +271,7 @@ func (c *VirConnection) DomainCreateXML(xmlConfig string, flags uint32) (VirDoma
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virDomainCreateXML(c.ptr, cXml, C.uint(flags))
 	if ptr == nil {
-		return VirDomain{}, errors.New(GetLastError())
+		return VirDomain{}, GetLastError()
 	}
 	return VirDomain{ptr: ptr}, nil
 }
@@ -286,7 +289,7 @@ func (c *VirConnection) DomainDefineXML(xmlConfig string) (VirDomain, error) {
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virDomainDefineXML(c.ptr, cXml)
 	if ptr == nil {
-		return VirDomain{}, errors.New(GetLastError())
+		return VirDomain{}, GetLastError()
 	}
 	return VirDomain{ptr: ptr}, nil
 }
@@ -300,7 +303,7 @@ func (c *VirConnection) ListDefinedInterfaces() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxIfaces)
 	if numIfaces == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numIfaces)
 	for k := 0; k < int(numIfaces); k++ {
@@ -319,7 +322,7 @@ func (c *VirConnection) ListDefinedNetworks() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxNets)
 	if numNetworks == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numNetworks)
 	for k := 0; k < int(numNetworks); k++ {
@@ -338,7 +341,7 @@ func (c *VirConnection) ListDefinedStoragePools() ([]string, error) {
 		(**C.char)(namesPtr),
 		maxPools)
 	if numStoragePools == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	goNames := make([]string, numStoragePools)
 	for k := 0; k < int(numStoragePools); k++ {
@@ -351,7 +354,7 @@ func (c *VirConnection) ListDefinedStoragePools() ([]string, error) {
 func (c *VirConnection) NumOfDefinedInterfaces() (int, error) {
 	result := int(C.virConnectNumOfDefinedInterfaces(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -359,7 +362,7 @@ func (c *VirConnection) NumOfDefinedInterfaces() (int, error) {
 func (c *VirConnection) NumOfDefinedNetworks() (int, error) {
 	result := int(C.virConnectNumOfDefinedNetworks(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -367,7 +370,7 @@ func (c *VirConnection) NumOfDefinedNetworks() (int, error) {
 func (c *VirConnection) NumOfDefinedStoragePools() (int, error) {
 	result := int(C.virConnectNumOfDefinedStoragePools(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -375,7 +378,7 @@ func (c *VirConnection) NumOfDefinedStoragePools() (int, error) {
 func (c *VirConnection) NumOfDomains() (int, error) {
 	result := int(C.virConnectNumOfDomains(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -383,7 +386,7 @@ func (c *VirConnection) NumOfDomains() (int, error) {
 func (c *VirConnection) NumOfInterfaces() (int, error) {
 	result := int(C.virConnectNumOfInterfaces(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -391,7 +394,7 @@ func (c *VirConnection) NumOfInterfaces() (int, error) {
 func (c *VirConnection) NumOfNetworks() (int, error) {
 	result := int(C.virConnectNumOfNetworks(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -399,7 +402,7 @@ func (c *VirConnection) NumOfNetworks() (int, error) {
 func (c *VirConnection) NumOfNWFilters() (int, error) {
 	result := int(C.virConnectNumOfNWFilters(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -407,7 +410,7 @@ func (c *VirConnection) NumOfNWFilters() (int, error) {
 func (c *VirConnection) NumOfSecrets() (int, error) {
 	result := int(C.virConnectNumOfSecrets(c.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -425,7 +428,7 @@ func (c *VirConnection) NetworkDefineXML(xmlConfig string) (VirNetwork, error) {
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virNetworkDefineXML(c.ptr, cXml)
 	if ptr == nil {
-		return VirNetwork{}, errors.New(GetLastError())
+		return VirNetwork{}, GetLastError()
 	}
 	return VirNetwork{ptr: ptr}, nil
 }
@@ -435,7 +438,7 @@ func (c *VirConnection) LookupNetworkByName(name string) (VirNetwork, error) {
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virNetworkLookupByName(c.ptr, cName)
 	if ptr == nil {
-		return VirNetwork{}, errors.New(GetLastError())
+		return VirNetwork{}, GetLastError()
 	}
 	return VirNetwork{ptr: ptr}, nil
 }
@@ -443,7 +446,7 @@ func (c *VirConnection) LookupNetworkByName(name string) (VirNetwork, error) {
 func (c *VirConnection) GetSysinfo(flags uint) (string, error) {
 	cStr := C.virConnectGetSysinfo(c.ptr, C.uint(flags))
 	if cStr == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	info := C.GoString(cStr)
 	C.free(unsafe.Pointer(cStr))
@@ -453,7 +456,7 @@ func (c *VirConnection) GetSysinfo(flags uint) (string, error) {
 func (c *VirConnection) GetURI() (string, error) {
 	cStr := C.virConnectGetURI(c.ptr)
 	if cStr == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	uri := C.GoString(cStr)
 	C.free(unsafe.Pointer(cStr))
@@ -468,7 +471,7 @@ func (c *VirConnection) GetMaxVcpus(typeAttr string) (int, error) {
 	}
 	result := int(C.virConnectGetMaxVcpus(c.ptr, cTypeAttr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -486,7 +489,7 @@ func (c *VirConnection) InterfaceDefineXML(xmlConfig string, flags uint32) (VirI
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virInterfaceDefineXML(c.ptr, cXml, C.uint(flags))
 	if ptr == nil {
-		return VirInterface{}, errors.New(GetLastError())
+		return VirInterface{}, GetLastError()
 	}
 	return VirInterface{ptr: ptr}, nil
 }
@@ -496,7 +499,7 @@ func (c *VirConnection) LookupInterfaceByName(name string) (VirInterface, error)
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virInterfaceLookupByName(c.ptr, cName)
 	if ptr == nil {
-		return VirInterface{}, errors.New(GetLastError())
+		return VirInterface{}, GetLastError()
 	}
 	return VirInterface{ptr: ptr}, nil
 }
@@ -506,7 +509,7 @@ func (c *VirConnection) LookupInterfaceByMACString(mac string) (VirInterface, er
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virInterfaceLookupByMACString(c.ptr, cName)
 	if ptr == nil {
-		return VirInterface{}, errors.New(GetLastError())
+		return VirInterface{}, GetLastError()
 	}
 	return VirInterface{ptr: ptr}, nil
 }
@@ -524,7 +527,7 @@ func (c *VirConnection) StoragePoolDefineXML(xmlConfig string, flags uint32) (Vi
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virStoragePoolDefineXML(c.ptr, cXml, C.uint(flags))
 	if ptr == nil {
-		return VirStoragePool{}, errors.New(GetLastError())
+		return VirStoragePool{}, GetLastError()
 	}
 	return VirStoragePool{ptr: ptr}, nil
 }
@@ -534,7 +537,7 @@ func (c *VirConnection) LookupStoragePoolByName(name string) (VirStoragePool, er
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virStoragePoolLookupByName(c.ptr, cName)
 	if ptr == nil {
-		return VirStoragePool{}, errors.New(GetLastError())
+		return VirStoragePool{}, GetLastError()
 	}
 	return VirStoragePool{ptr: ptr}, nil
 }
@@ -544,7 +547,7 @@ func (c *VirConnection) LookupStoragePoolByUUIDString(uuid string) (VirStoragePo
 	defer C.free(unsafe.Pointer(cUuid))
 	ptr := C.virStoragePoolLookupByUUIDString(c.ptr, cUuid)
 	if ptr == nil {
-		return VirStoragePool{}, errors.New(GetLastError())
+		return VirStoragePool{}, GetLastError()
 	}
 	return VirStoragePool{ptr: ptr}, nil
 }
@@ -562,7 +565,7 @@ func (c *VirConnection) NWFilterDefineXML(xmlConfig string) (VirNWFilter, error)
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virNWFilterDefineXML(c.ptr, cXml)
 	if ptr == nil {
-		return VirNWFilter{}, errors.New(GetLastError())
+		return VirNWFilter{}, GetLastError()
 	}
 	return VirNWFilter{ptr: ptr}, nil
 }
@@ -572,7 +575,7 @@ func (c *VirConnection) LookupNWFilterByName(name string) (VirNWFilter, error) {
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virNWFilterLookupByName(c.ptr, cName)
 	if ptr == nil {
-		return VirNWFilter{}, errors.New(GetLastError())
+		return VirNWFilter{}, GetLastError()
 	}
 	return VirNWFilter{ptr: ptr}, nil
 }
@@ -582,7 +585,7 @@ func (c *VirConnection) LookupNWFilterByUUIDString(uuid string) (VirNWFilter, er
 	defer C.free(unsafe.Pointer(cUuid))
 	ptr := C.virNWFilterLookupByUUIDString(c.ptr, cUuid)
 	if ptr == nil {
-		return VirNWFilter{}, errors.New(GetLastError())
+		return VirNWFilter{}, GetLastError()
 	}
 	return VirNWFilter{ptr: ptr}, nil
 }
@@ -592,7 +595,7 @@ func (c *VirConnection) LookupStorageVolByKey(key string) (VirStorageVol, error)
 	defer C.free(unsafe.Pointer(cKey))
 	ptr := C.virStorageVolLookupByKey(c.ptr, cKey)
 	if ptr == nil {
-		return VirStorageVol{}, errors.New(GetLastError())
+		return VirStorageVol{}, GetLastError()
 	}
 	return VirStorageVol{ptr: ptr}, nil
 }
@@ -602,7 +605,7 @@ func (c *VirConnection) LookupStorageVolByPath(path string) (VirStorageVol, erro
 	defer C.free(unsafe.Pointer(cPath))
 	ptr := C.virStorageVolLookupByPath(c.ptr, cPath)
 	if ptr == nil {
-		return VirStorageVol{}, errors.New(GetLastError())
+		return VirStorageVol{}, GetLastError()
 	}
 	return VirStorageVol{ptr: ptr}, nil
 }
@@ -620,7 +623,7 @@ func (c *VirConnection) SecretDefineXML(xmlConfig string, flags uint32) (VirSecr
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virSecretDefineXML(c.ptr, cXml, C.uint(flags))
 	if ptr == nil {
-		return VirSecret{}, errors.New(GetLastError())
+		return VirSecret{}, GetLastError()
 	}
 	return VirSecret{ptr: ptr}, nil
 }
@@ -630,7 +633,7 @@ func (c *VirConnection) LookupSecretByUUIDString(uuid string) (VirSecret, error)
 	defer C.free(unsafe.Pointer(cUuid))
 	ptr := C.virSecretLookupByUUIDString(c.ptr, cUuid)
 	if ptr == nil {
-		return VirSecret{}, errors.New(GetLastError())
+		return VirSecret{}, GetLastError()
 	}
 	return VirSecret{ptr: ptr}, nil
 }
@@ -640,7 +643,7 @@ func (c *VirConnection) LookupSecretByUsage(usageType int, usageID string) (VirS
 	defer C.free(unsafe.Pointer(cUsageID))
 	ptr := C.virSecretLookupByUsage(c.ptr, C.int(usageType), cUsageID)
 	if ptr == nil {
-		return VirSecret{}, errors.New(GetLastError())
+		return VirSecret{}, GetLastError()
 	}
 	return VirSecret{ptr: ptr}, nil
 }
@@ -649,7 +652,7 @@ func (c *VirConnection) ListAllInterfaces(flags uint32) ([]VirInterface, error) 
 	var cList *C.virInterfacePtr
 	numIfaces := C.virConnectListAllInterfaces(c.ptr, (**C.virInterfacePtr)(&cList), C.uint(flags))
 	if numIfaces == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cList)),
@@ -669,7 +672,7 @@ func (c *VirConnection) ListAllNetworks(flags uint32) ([]VirNetwork, error) {
 	var cList *C.virNetworkPtr
 	numNets := C.virConnectListAllNetworks(c.ptr, (**C.virNetworkPtr)(&cList), C.uint(flags))
 	if numNets == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cList)),
@@ -689,7 +692,7 @@ func (c *VirConnection) ListAllDomains(flags uint32) ([]VirDomain, error) {
 	var cList *C.virDomainPtr
 	numDomains := C.virConnectListAllDomains(c.ptr, (**C.virDomainPtr)(&cList), C.uint(flags))
 	if numDomains == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cList)),
@@ -709,7 +712,7 @@ func (c *VirConnection) ListAllNWFilters(flags uint32) ([]VirNWFilter, error) {
 	var cList *C.virNWFilterPtr
 	numNWFilters := C.virConnectListAllNWFilters(c.ptr, (**C.virNWFilterPtr)(&cList), C.uint(flags))
 	if numNWFilters == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cList)),
@@ -729,7 +732,7 @@ func (c *VirConnection) ListAllStoragePools(flags uint32) ([]VirStoragePool, err
 	var cList *C.virStoragePoolPtr
 	numPools := C.virConnectListAllStoragePools(c.ptr, (**C.virStoragePoolPtr)(&cList), C.uint(flags))
 	if numPools == -1 {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cList)),

--- a/network.go
+++ b/network.go
@@ -19,7 +19,7 @@ type VirNetwork struct {
 
 func (n *VirNetwork) Free() error {
 	if result := C.virNetworkFree(n.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -27,7 +27,7 @@ func (n *VirNetwork) Free() error {
 func (n *VirNetwork) Create() error {
 	result := C.virNetworkCreate(n.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -35,7 +35,7 @@ func (n *VirNetwork) Create() error {
 func (n *VirNetwork) Destroy() error {
 	result := C.virNetworkDestroy(n.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -43,7 +43,7 @@ func (n *VirNetwork) Destroy() error {
 func (n *VirNetwork) IsActive() (bool, error) {
 	result := C.virNetworkIsActive(n.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -54,7 +54,7 @@ func (n *VirNetwork) IsActive() (bool, error) {
 func (n *VirNetwork) IsPersistent() (bool, error) {
 	result := C.virNetworkIsPersistent(n.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -66,7 +66,7 @@ func (n *VirNetwork) GetAutostart() (bool, error) {
 	var out C.int
 	result := C.virNetworkGetAutostart(n.ptr, (*C.int)(unsafe.Pointer(&out)))
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	switch out {
 	case 1:
@@ -86,7 +86,7 @@ func (n *VirNetwork) SetAutostart(autostart bool) error {
 	}
 	result := C.virNetworkSetAutostart(n.ptr, cAutostart)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func (n *VirNetwork) SetAutostart(autostart bool) error {
 func (n *VirNetwork) GetName() (string, error) {
 	name := C.virNetworkGetName(n.ptr)
 	if name == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(name), nil
 }
@@ -104,7 +104,7 @@ func (n *VirNetwork) GetUUID() ([]byte, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virNetworkGetUUID(n.ptr, (*C.uchar)(cuidPtr))
 	if result != 0 {
-		return []byte{}, errors.New(GetLastError())
+		return []byte{}, GetLastError()
 	}
 	return C.GoBytes(cuidPtr, C.VIR_UUID_BUFLEN), nil
 }
@@ -114,7 +114,7 @@ func (n *VirNetwork) GetUUIDString() (string, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virNetworkGetUUIDString(n.ptr, (*C.char)(cuidPtr))
 	if result != 0 {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString((*C.char)(cuidPtr)), nil
 }
@@ -122,7 +122,7 @@ func (n *VirNetwork) GetUUIDString() (string, error) {
 func (n *VirNetwork) GetBridgeName() (string, error) {
 	result := C.virNetworkGetBridgeName(n.ptr)
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	bridge := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -132,7 +132,7 @@ func (n *VirNetwork) GetBridgeName() (string, error) {
 func (n *VirNetwork) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virNetworkGetXMLDesc(n.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -142,7 +142,7 @@ func (n *VirNetwork) GetXMLDesc(flags uint32) (string, error) {
 func (n *VirNetwork) Undefine() error {
 	result := C.virNetworkUndefine(n.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }

--- a/nwfilter.go
+++ b/nwfilter.go
@@ -19,7 +19,7 @@ type VirNWFilter struct {
 
 func (f *VirNWFilter) Free() error {
 	if result := C.virNWFilterFree(f.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -27,7 +27,7 @@ func (f *VirNWFilter) Free() error {
 func (f *VirNWFilter) GetName() (string, error) {
 	name := C.virNWFilterGetName(f.ptr)
 	if name == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(name), nil
 }
@@ -35,7 +35,7 @@ func (f *VirNWFilter) GetName() (string, error) {
 func (f *VirNWFilter) Undefine() error {
 	result := C.virNWFilterUndefine(f.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -45,7 +45,7 @@ func (f *VirNWFilter) GetUUID() ([]byte, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virNWFilterGetUUID(f.ptr, (*C.uchar)(cuidPtr))
 	if result != 0 {
-		return []byte{}, errors.New(GetLastError())
+		return []byte{}, GetLastError()
 	}
 	return C.GoBytes(cuidPtr, C.VIR_UUID_BUFLEN), nil
 }
@@ -55,7 +55,7 @@ func (f *VirNWFilter) GetUUIDString() (string, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virNWFilterGetUUIDString(f.ptr, (*C.char)(cuidPtr))
 	if result != 0 {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString((*C.char)(cuidPtr)), nil
 }
@@ -63,7 +63,7 @@ func (f *VirNWFilter) GetUUIDString() (string, error) {
 func (f *VirNWFilter) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virNWFilterGetXMLDesc(f.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))

--- a/secret.go
+++ b/secret.go
@@ -19,7 +19,7 @@ type VirSecret struct {
 
 func (s *VirSecret) Free() error {
 	if result := C.virSecretFree(s.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -27,7 +27,7 @@ func (s *VirSecret) Free() error {
 func (s *VirSecret) Undefine() error {
 	result := C.virSecretUndefine(s.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -37,7 +37,7 @@ func (s *VirSecret) GetUUID() ([]byte, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virSecretGetUUID(s.ptr, (*C.uchar)(cuidPtr))
 	if result != 0 {
-		return []byte{}, errors.New(GetLastError())
+		return []byte{}, GetLastError()
 	}
 	return C.GoBytes(cuidPtr, C.VIR_UUID_BUFLEN), nil
 }
@@ -47,7 +47,7 @@ func (s *VirSecret) GetUUIDString() (string, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virSecretGetUUIDString(s.ptr, (*C.char)(cuidPtr))
 	if result != 0 {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString((*C.char)(cuidPtr)), nil
 }
@@ -55,7 +55,7 @@ func (s *VirSecret) GetUUIDString() (string, error) {
 func (s *VirSecret) GetUsageID() (string, error) {
 	result := C.virSecretGetUsageID(s.ptr)
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(result), nil
 }
@@ -63,7 +63,7 @@ func (s *VirSecret) GetUsageID() (string, error) {
 func (s *VirSecret) GetUsageType() (int, error) {
 	result := int(C.virSecretGetUsageType(s.ptr))
 	if result == -1 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	return result, nil
 }
@@ -71,7 +71,7 @@ func (s *VirSecret) GetUsageType() (int, error) {
 func (s *VirSecret) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virSecretGetXMLDesc(s.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))

--- a/snapshot.go
+++ b/snapshot.go
@@ -19,7 +19,7 @@ type VirDomainSnapshot struct {
 
 func (s *VirDomainSnapshot) Free() error {
 	if result := C.virDomainSnapshotFree(s.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -29,7 +29,7 @@ func (d *VirDomain) CreateSnapshotXML(xml string, flags uint32) (VirDomainSnapsh
 	defer C.free(unsafe.Pointer(cXml))
 	result := C.virDomainSnapshotCreateXML(d.ptr, cXml, C.uint(flags))
 	if result == nil {
-		return VirDomainSnapshot{}, errors.New(GetLastError())
+		return VirDomainSnapshot{}, GetLastError()
 	}
 	return VirDomainSnapshot{ptr: result}, nil
 }
@@ -39,7 +39,7 @@ func (d *VirDomain) Save(destFile string) error {
 	defer C.free(unsafe.Pointer(cPath))
 	result := C.virDomainSave(d.ptr, cPath)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -51,7 +51,7 @@ func (d *VirDomain) SaveFlags(destFile string, destXml string, flags uint32) err
 	defer C.free(unsafe.Pointer(cDestFile))
 	result := C.virDomainSaveFlags(d.ptr, cDestFile, cDestXml, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func (conn VirConnection) Restore(srcFile string) error {
 	cPath := C.CString(srcFile)
 	defer C.free(unsafe.Pointer(cPath))
 	if result := C.virDomainRestore(conn.ptr, cPath); result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -74,7 +74,7 @@ func (conn VirConnection) RestoreFlags(srcFile, xmlConf string, flags uint32) er
 		defer C.free(unsafe.Pointer(cXmlConf))
 	}
 	if result := C.virDomainRestoreFlags(conn.ptr, cPath, cXmlConf, C.uint(flags)); result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }

--- a/storage_pool.go
+++ b/storage_pool.go
@@ -25,7 +25,7 @@ type VirStoragePoolInfo struct {
 func (p *VirStoragePool) Build(flags uint32) error {
 	result := C.virStoragePoolBuild(p.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -33,7 +33,7 @@ func (p *VirStoragePool) Build(flags uint32) error {
 func (p *VirStoragePool) Create(flags uint32) error {
 	result := C.virStoragePoolCreate(p.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func (p *VirStoragePool) Create(flags uint32) error {
 func (p *VirStoragePool) Delete(flags uint32) error {
 	result := C.virStoragePoolDelete(p.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -49,14 +49,14 @@ func (p *VirStoragePool) Delete(flags uint32) error {
 func (p *VirStoragePool) Destroy() error {
 	result := C.virStoragePoolDestroy(p.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
 
 func (p *VirStoragePool) Free() error {
 	if result := C.virStoragePoolFree(p.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (p *VirStoragePool) GetAutostart() (bool, error) {
 	var out C.int
 	result := C.virStoragePoolGetAutostart(p.ptr, (*C.int)(unsafe.Pointer(&out)))
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	switch out {
 	case 1:
@@ -80,7 +80,7 @@ func (p *VirStoragePool) GetInfo() (VirStoragePoolInfo, error) {
 	var ptr C.virStoragePoolInfo
 	result := C.virStoragePoolGetInfo(p.ptr, (*C.virStoragePoolInfo)(unsafe.Pointer(&ptr)))
 	if result == -1 {
-		return pi, errors.New(GetLastError())
+		return pi, GetLastError()
 	}
 	pi.ptr = ptr
 	return pi, nil
@@ -89,7 +89,7 @@ func (p *VirStoragePool) GetInfo() (VirStoragePoolInfo, error) {
 func (p *VirStoragePool) GetName() (string, error) {
 	name := C.virStoragePoolGetName(p.ptr)
 	if name == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(name), nil
 }
@@ -99,7 +99,7 @@ func (p *VirStoragePool) GetUUID() ([]byte, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virStoragePoolGetUUID(p.ptr, (*C.uchar)(cuidPtr))
 	if result != 0 {
-		return []byte{}, errors.New(GetLastError())
+		return []byte{}, GetLastError()
 	}
 	return C.GoBytes(cuidPtr, C.VIR_UUID_BUFLEN), nil
 }
@@ -109,7 +109,7 @@ func (p *VirStoragePool) GetUUIDString() (string, error) {
 	cuidPtr := unsafe.Pointer(&cUuid)
 	result := C.virStoragePoolGetUUIDString(p.ptr, (*C.char)(cuidPtr))
 	if result != 0 {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString((*C.char)(cuidPtr)), nil
 }
@@ -117,7 +117,7 @@ func (p *VirStoragePool) GetUUIDString() (string, error) {
 func (p *VirStoragePool) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virStoragePoolGetXMLDesc(p.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -127,7 +127,7 @@ func (p *VirStoragePool) GetXMLDesc(flags uint32) (string, error) {
 func (p *VirStoragePool) IsActive() (bool, error) {
 	result := C.virStoragePoolIsActive(p.ptr)
 	if result == -1 {
-		return false, errors.New(GetLastError())
+		return false, GetLastError()
 	}
 	if result == 1 {
 		return true, nil
@@ -145,7 +145,7 @@ func (p *VirStoragePool) SetAutostart(autostart bool) error {
 	}
 	result := C.virStoragePoolSetAutostart(p.ptr, cAutostart)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -153,7 +153,7 @@ func (p *VirStoragePool) SetAutostart(autostart bool) error {
 func (p *VirStoragePool) Refresh(flags uint32) error {
 	result := C.virStoragePoolRefresh(p.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (p *VirStoragePool) Refresh(flags uint32) error {
 func (p *VirStoragePool) Undefine() error {
 	result := C.virStoragePoolUndefine(p.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func (p *VirStoragePool) StorageVolCreateXML(xmlConfig string, flags uint32) (Vi
 	defer C.free(unsafe.Pointer(cXml))
 	ptr := C.virStorageVolCreateXML(p.ptr, cXml, C.uint(flags))
 	if ptr == nil {
-		return VirStorageVol{}, errors.New(GetLastError())
+		return VirStorageVol{}, GetLastError()
 	}
 	return VirStorageVol{ptr: ptr}, nil
 }
@@ -205,7 +205,7 @@ func (p *VirStoragePool) LookupStorageVolByName(name string) (VirStorageVol, err
 	defer C.free(unsafe.Pointer(cName))
 	ptr := C.virStorageVolLookupByName(p.ptr, cName)
 	if ptr == nil {
-		return VirStorageVol{}, errors.New(GetLastError())
+		return VirStorageVol{}, GetLastError()
 	}
 	return VirStorageVol{ptr: ptr}, nil
 }

--- a/storage_volume.go
+++ b/storage_volume.go
@@ -24,14 +24,14 @@ type VirStorageVolInfo struct {
 func (v *VirStorageVol) Delete(flags uint32) error {
 	result := C.virStorageVolDelete(v.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
 
 func (v *VirStorageVol) Free() error {
 	if result := C.virStorageVolFree(v.ptr); result != 0 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func (v *VirStorageVol) GetInfo() (VirStorageVolInfo, error) {
 	var ptr C.virStorageVolInfo
 	result := C.virStorageVolGetInfo(v.ptr, (*C.virStorageVolInfo)(unsafe.Pointer(&ptr)))
 	if result == -1 {
-		return vi, errors.New(GetLastError())
+		return vi, GetLastError()
 	}
 	vi.ptr = ptr
 	return vi, nil
@@ -62,7 +62,7 @@ func (i *VirStorageVolInfo) GetAllocationInBytes() uint64 {
 func (v *VirStorageVol) GetKey() (string, error) {
 	key := C.virStorageVolGetKey(v.ptr)
 	if key == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(key), nil
 }
@@ -70,7 +70,7 @@ func (v *VirStorageVol) GetKey() (string, error) {
 func (v *VirStorageVol) GetName() (string, error) {
 	name := C.virStorageVolGetName(v.ptr)
 	if name == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	return C.GoString(name), nil
 }
@@ -78,7 +78,7 @@ func (v *VirStorageVol) GetName() (string, error) {
 func (v *VirStorageVol) GetPath() (string, error) {
 	result := C.virStorageVolGetPath(v.ptr)
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	path := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -88,7 +88,7 @@ func (v *VirStorageVol) GetPath() (string, error) {
 func (v *VirStorageVol) GetXMLDesc(flags uint32) (string, error) {
 	result := C.virStorageVolGetXMLDesc(v.ptr, C.uint(flags))
 	if result == nil {
-		return "", errors.New(GetLastError())
+		return "", GetLastError()
 	}
 	xml := C.GoString(result)
 	C.free(unsafe.Pointer(result))
@@ -98,7 +98,7 @@ func (v *VirStorageVol) GetXMLDesc(flags uint32) (string, error) {
 func (v *VirStorageVol) Resize(capacity uint64, flags uint32) error {
 	result := C.virStorageVolResize(v.ptr, C.ulonglong(capacity), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
@@ -106,14 +106,14 @@ func (v *VirStorageVol) Resize(capacity uint64, flags uint32) error {
 func (v *VirStorageVol) Wipe(flags uint32) error {
 	result := C.virStorageVolWipe(v.ptr, C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }
 func (v *VirStorageVol) WipePattern(algorithm uint32, flags uint32) error {
 	result := C.virStorageVolWipePattern(v.ptr, C.uint(algorithm), C.uint(flags))
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -20,7 +20,7 @@ type VirStream struct {
 func NewVirStream(c *VirConnection, flags uint) (*VirStream, error) {
 	virStream := C.virStreamNew(c.ptr, C.uint(flags))
 	if virStream == nil {
-		return nil, errors.New(GetLastError())
+		return nil, GetLastError()
 	}
 
 	return &VirStream{
@@ -31,7 +31,7 @@ func NewVirStream(c *VirConnection, flags uint) (*VirStream, error) {
 func (v *VirStream) Abort() error {
 	result := C.virStreamAbort(v.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 
 	return nil
@@ -40,7 +40,7 @@ func (v *VirStream) Abort() error {
 func (v *VirStream) Close() error {
 	result := C.virStreamFinish(v.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 
 	return nil
@@ -49,7 +49,7 @@ func (v *VirStream) Close() error {
 func (v *VirStream) Free() error {
 	result := C.virStreamFree(v.ptr)
 	if result == -1 {
-		return errors.New(GetLastError())
+		return GetLastError()
 	}
 
 	return nil
@@ -58,7 +58,7 @@ func (v *VirStream) Free() error {
 func (v *VirStream) Read(p []byte) (int, error) {
 	n := C.virStreamRecv(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
 	if n < 0 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	if n == 0 {
 		return 0, io.EOF
@@ -70,7 +70,7 @@ func (v *VirStream) Read(p []byte) (int, error) {
 func (v *VirStream) Write(p []byte) (int, error) {
 	n := C.virStreamSend(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
 	if n < 0 {
-		return 0, errors.New(GetLastError())
+		return 0, GetLastError()
 	}
 	if n == 0 {
 		return 0, io.EOF


### PR DESCRIPTION
**Note**: this commit changes libvirt.GetLastError() return value. I'm not sure if it's OK to break API compatibility. Otherwise, we could try to find another name for it.

Changed GetLastError to return VirError instead of a simple string.
VirError helps getting easy access to the error code, level and domain.
VirError implements the error interface for easy use.
