### PR TITLE
Added Dockerfile to run the tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM		debian:wheezy
+MAINTAINER	Cedric Bosdonnat <cbosdonnat@suse.com>
+
+# Deps
+RUN echo 'deb http://http.debian.net/debian wheezy-backports main' >> /etc/apt/sources.list.d/backports.list
+RUN apt-get update && \
+    DEBCONF_FRONTEND=noninteractive DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl \
+    gcc \
+	libvirt0=1.2.* \
+	libvirt-dev=1.2.* \
+	libvirt-bin=1.2.*
+
+# Install Go
+RUN curl -sSL https://golang.org/dl/go1.3.1.src.tar.gz | tar -v -C /usr/local -xz
+ENV GOROOT	/usr/local/go
+ENV PATH    /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH  /go:/go/src/github.com/docker/docker/vendor
+RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
+
+WORKDIR	/libvirt-go
+COPY . /libvirt-go
+
+ENTRYPOINT ["./run-libvirt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ ENV PATH    /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH  /go:/go/src/github.com/docker/docker/vendor
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
+# Setup the network properly
+RUN /bin/echo -e 'auto lo\niface lo inet loopback\nallow-hotplug eth0\niface eth0 inet dhcp\n' \
+    >/etc/network/interfaces
+
 WORKDIR	/libvirt-go
 COPY . /libvirt-go
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+build:
+	docker build -t libvirt-go:master .
+
+unit-test: build
+	docker run -ti --privileged --rm libvirt-go:master go test
+
+integration-test: build
+	docker run -ti --privileged --rm libvirt-go:master go test -tags integration
+
+test: unit-test integration-test

--- a/integration_test.go
+++ b/integration_test.go
@@ -668,14 +668,19 @@ func TestIntegrationGetDomainCPUStats(t *testing.T) {
 	}
 	defer dom.Destroy()
 
+    nodeinfo, err := conn.GetNodeInfo()
+    if err != nil {
+		t.Fatal(err)
+    }
+
 	// ... if @params is NULL and @nparams is 0 and @ncpus is 0, the
 	// number of cpus available to query is returned. From the host perspective,
 	ncpus, err := dom.GetCPUStats(nil, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ncpus != 1 {
-		t.Fatal("Number of CPUs should be 1")
+	if ncpus != int(nodeinfo.GetCPUs()) {
+		t.Fatal("LXC guest number of CPUs should equals the host number of CPUs")
 	}
 
 	// ... if @params is NULL and @nparams is 0 and @ncpus is 1,
@@ -696,8 +701,8 @@ func TestIntegrationGetDomainCPUStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(params) != lxcNumParams {
-		t.Fatalf("Wanted %d returned parameters, got %d", lxcNumParams, len(params))
+	if len(params) != int(nodeinfo.GetCPUs()) {
+		t.Fatalf("Wanted %d returned parameters, got %d", int(nodeinfo.GetCPUs()), len(params))
 	}
 	param := params[0]
 	if param.Name != lxcParamName {

--- a/run-libvirt
+++ b/run-libvirt
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+# See the blog post: http://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privilieged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/cgroup
+
+mkdir -p "$CGROUP"
+
+if ! mountpoint -q "$CGROUP"; then
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
+		exit 1
+	}
+fi
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+	mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and -privileged mode might break.'
+	}
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup); do
+	mkdir -p "$CGROUP/$SUBSYS"
+	if ! mountpoint -q $CGROUP/$SUBSYS; then
+		mount -n -t cgroup -o "$SUBSYS" cgroup "$CGROUP/$SUBSYS"
+	fi
+
+	# The two following sections address a bug which manifests itself
+	# by a cryptic "lxc-start: no ns_cgroup option specified" when
+	# trying to start containers withina container.
+	# The bug seems to appear when the cgroup hierarchies are not
+	# mounted on the exact same directories in the host, and in the
+	# container.
+
+	# Named, control-less cgroups are mounted with "-o name=foo"
+	# (and appear as such under /proc/<pid>/cgroup) but are usually
+	# mounted on a directory named "foo" (without the "name=" prefix).
+	# Systemd and OpenRC (and possibly others) both create such a
+	# cgroup. To avoid the aforementioned bug, we symlink "foo" to
+	# "name=foo". This shouldn't have any adverse effect.
+	name="${SUBSYS#name=}"
+	if [ "$name" != "$SUBSYS" ]; then
+		ln -s "$SUBSYS" "$CGROUP/$name"
+	fi
+
+	# Likewise, on at least one system, it has been reported that
+	# systemd would mount the CPU and CPU accounting controllers
+	# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+	# but on a directory called "cpu,cpuacct" (note the inversion
+	# in the order of the groups). This tries to work around it.
+	if [ "$SUBSYS" = 'cpuacct,cpu' ]; then
+		ln -s "$SUBSYS" "$CGROUP/cpu,cpuacct"
+	fi
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+if ! grep -q :devices: /proc/1/cgroup; then
+	echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
+fi
+if ! grep -qw devices /proc/1/cgroup; then
+	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
+fi
+
+# Mount /tmp
+mount -t tmpfs none /tmp
+
+# Silently start libvirtd, need for the tests
+/usr/sbin/libvirtd >/dev/null 2>&1 &
+
+# Execute the command passed in arguments
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run a shell?'


### PR DESCRIPTION
**Disclaimer:** *I am aware that this commit may be considered useless by vagrant fans, however, vagrant+virtualbox is a nogo on my dev machine running KVM.*

Vagrant has the inconvenient to be depending on VirtualBox, while
docker is just easy to setup. To run the tests, just run those two
commands:

    sudo docker build -t libvirt-go:master .
    sudo docker run -ti --rm libvirt-go:master

This could be made even easier through a simple Makefile