### PR TITLE
Add methods to follow default lookup path for connections

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -80,10 +80,28 @@ func NewVirConnection(uri string) (VirConnection, error) {
 	return obj, nil
 }
 
+func NewVirConnectionDefault() (VirConnection, error) {
+	ptr := C.virConnectOpen(nil)
+	if ptr == nil {
+		return VirConnection{}, GetLastError()
+	}
+	obj := VirConnection{ptr: ptr}
+	return obj, nil
+}
+
 func NewVirConnectionReadOnly(uri string) (VirConnection, error) {
 	cUri := C.CString(uri)
 	defer C.free(unsafe.Pointer(cUri))
 	ptr := C.virConnectOpenReadOnly(cUri)
+	if ptr == nil {
+		return VirConnection{}, GetLastError()
+	}
+	obj := VirConnection{ptr: ptr}
+	return obj, nil
+}
+
+func NewVirConnectionReadOnlyDefault() (VirConnection, error) {
+	ptr := C.virConnectOpenReadOnly(nil)
 	if ptr == nil {
 		return VirConnection{}, GetLastError()
 	}


### PR DESCRIPTION
Passing NULL for this string causes libvirt to try some sane defaults. The current API provided here doesn't allow passing NULL. 

I haven't tested this yet. Merge or close, doesn't matter much to me; I'm just using a fork in my project.
