### PR TITLE
Don't build Domain Event callbacks in Golang 1.6

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -1,14 +1,18 @@
+//+build !go1.6
+
 package libvirt
+
+/*
+ * Golang 1.6 doesn't support C pointers to go memory.
+ * A hacky-solution might be some multi-threaded approach to support domain events, but let's make it work
+ * without domain events for now.
+ */
 
 /*
 #cgo LDFLAGS: -lvirt 
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>
-
-void virErrorFuncDummy(void *userData, virErrorPtr error)
-{
-}
 
 int domainEventLifecycleCallback_cgo(virConnectPtr c, virDomainPtr d,
                                      int event, int detail, void *data)

--- a/libvirt.go
+++ b/libvirt.go
@@ -15,49 +15,10 @@ import (
 
 void virErrorFuncDummy(void *userData, virErrorPtr error);
 
-int domainEventLifecycleCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                     int event, int detail, void* data);
+void virErrorFuncDummy(void *userData, virErrorPtr error)
+{
+}
 
-int domainEventGenericCallback_cgo(virConnectPtr c, virDomainPtr d, void* data);
-
-int domainEventRTCChangeCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                     long long utcoffset, void* data);
-
-int domainEventWatchdogCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                    int action, void* data);
-
-int domainEventIOErrorCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                   const char *srcPath, const char *devAlias,
-                                   int action, void* data);
-
-int domainEventGraphicsCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                    int phase, const virDomainEventGraphicsAddress *local,
-                                    const virDomainEventGraphicsAddress *remote,
-                                    const char *authScheme,
-                                    const virDomainEventGraphicsSubject *subject, void* data);
-
-int domainEventIOErrorReasonCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                         const char *srcPath, const char *devAlias,
-                                         int action, const char *reason, void* data);
-
-int domainEventBlockJobCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                    const char *disk, int type, int status, void* data);
-
-int domainEventDiskChangeCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                      const char *oldSrcPath, const char *newSrcPath,
-                                      const char *devAlias, int reason, void* data);
-
-int domainEventTrayChangeCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                      const char *devAlias, int reason, void* data);
-
-int domainEventReasonCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                  int reason, void* data);
-
-int domainEventBalloonChangeCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                         unsigned long long actual, void* data);
-
-int domainEventDeviceRemovedCallback_cgo(virConnectPtr c, virDomainPtr d,
-                                         const char *devAlias, void* data);
 */
 import "C"
 
@@ -827,76 +788,4 @@ func (c *VirConnection) ListAllStoragePools(flags uint32) ([]VirStoragePool, err
 	}
 	C.free(unsafe.Pointer(cList))
 	return pools, nil
-}
-
-type DomainEventCallback func(c *VirConnection, d *VirDomain,
-	event interface{}, f func()) int
-
-type domainCallbackContext struct {
-	cb *DomainEventCallback
-	f  func()
-}
-
-func (c *VirConnection) DomainEventRegister(dom VirDomain,
-	eventId int,
-	callback *DomainEventCallback,
-	opaque func()) int {
-	var callbackPtr unsafe.Pointer
-	context := domainCallbackContext{
-		cb: callback,
-		f:  opaque,
-	}
-
-	switch eventId {
-	case VIR_DOMAIN_EVENT_ID_LIFECYCLE:
-		callbackPtr = unsafe.Pointer(C.domainEventLifecycleCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_REBOOT:
-	case VIR_DOMAIN_EVENT_ID_CONTROL_ERROR:
-		callbackPtr = unsafe.Pointer(C.domainEventGenericCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_RTC_CHANGE:
-		callbackPtr = unsafe.Pointer(C.domainEventRTCChangeCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_WATCHDOG:
-		callbackPtr = unsafe.Pointer(C.domainEventWatchdogCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_IO_ERROR:
-		callbackPtr = unsafe.Pointer(C.domainEventIOErrorCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_GRAPHICS:
-		callbackPtr = unsafe.Pointer(C.domainEventGraphicsCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_IO_ERROR_REASON:
-		callbackPtr = unsafe.Pointer(C.domainEventIOErrorReasonCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_BLOCK_JOB:
-		// TODO Post 1.2.4, uncomment later
-		// case VIR_DOMAIN_EVENT_ID_BLOCK_JOB_2:
-		callbackPtr = unsafe.Pointer(C.domainEventBlockJobCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_DISK_CHANGE:
-		callbackPtr = unsafe.Pointer(C.domainEventDiskChangeCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_TRAY_CHANGE:
-		callbackPtr = unsafe.Pointer(C.domainEventTrayChangeCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_PMWAKEUP:
-	case VIR_DOMAIN_EVENT_ID_PMSUSPEND:
-	case VIR_DOMAIN_EVENT_ID_PMSUSPEND_DISK:
-		callbackPtr = unsafe.Pointer(C.domainEventReasonCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_BALLOON_CHANGE:
-		callbackPtr = unsafe.Pointer(C.domainEventBalloonChangeCallback_cgo)
-	case VIR_DOMAIN_EVENT_ID_DEVICE_REMOVED:
-		callbackPtr = unsafe.Pointer(C.domainEventDeviceRemovedCallback_cgo)
-	default:
-	}
-	ret := C.virConnectDomainEventRegisterAny(c.ptr, dom.ptr, C.VIR_DOMAIN_EVENT_ID_LIFECYCLE,
-		C.virConnectDomainEventGenericCallback(callbackPtr),
-		unsafe.Pointer(&context),
-		nil)
-	return int(ret)
-}
-
-func (c *VirConnection) DomainEventDeregister(callbackId int) int {
-	// Deregister the callback
-	return int(C.virConnectDomainEventDeregisterAny(c.ptr, C.int(callbackId)))
-}
-
-func EventRegisterDefaultImpl() int {
-	return int(C.virEventRegisterDefaultImpl())
-}
-
-func EventRunDefaultImpl() int {
-	return int(C.virEventRunDefaultImpl())
 }


### PR DESCRIPTION
Issue #64 : Golang 1.6 doesn't support C pointers to go memory, so they don't build anyway.

A hacky-solution might be some multi-threaded approach to support domain events,
but let's make the rest of the bindings work without domain events for now
until a permanent solution comes later. 