### PR TITLE
QEMU Monitor Command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Carving out the future
 
-With the upcoming changes to cgo in Go 1.6 this package will probably break. We'll need to update it and crank through PRs together. Let's get things in :ship: shape.
+Go 1.6 is incompatible with libvirt's implementation of Domain Events (those things that callback to your code to let you know something changed in a domain's state), so builds of this under golang 1.6 will not include Domain Events unless someone comes up with a workaround.
 
 # libvirt-go
 

--- a/constants.go
+++ b/constants.go
@@ -383,3 +383,18 @@ const (
 	VIR_DOMAIN_EVENT_TRAY_CHANGE_OPEN  = C.VIR_DOMAIN_EVENT_TRAY_CHANGE_OPEN
 	VIR_DOMAIN_EVENT_TRAY_CHANGE_CLOSE = C.VIR_DOMAIN_EVENT_TRAY_CHANGE_CLOSE
 )
+
+/*
+ * QMP has two different kinds of ways to talk to QEMU. One is legacy (HMP,
+ * or 'human' monitor protocol. The default is QMP, which is all-JSON.
+ *
+ * QMP json commands are of the format:
+ * 	{"execute" : "query-cpus"}
+ *
+ * whereas the same command in 'HMP' would be:
+ *	'info cpus'
+ */
+const (
+	VIR_DOMAIN_QEMU_MONITOR_COMMAND_DEFAULT = 0
+	VIR_DOMAIN_QEMU_MONITOR_COMMAND_HMP = (1 << 0)
+)

--- a/domain.go
+++ b/domain.go
@@ -1,8 +1,9 @@
 package libvirt
 
 /*
-#cgo LDFLAGS: -lvirt
+#cgo LDFLAGS: -lvirt-qemu -lvirt
 #include <libvirt/libvirt.h>
+#include <libvirt/libvirt-qemu.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>
 */
@@ -665,4 +666,19 @@ func (d *VirDomain) GetVcpusFlags(flags uint32) (int32, error) {
 		return 0, GetLastError()
 	}
 	return int32(result), nil
+}
+
+func (d *VirDomain) QemuMonitorCommand(flags uint32, command string) (string, error) {
+	var cResult *C.char
+	cCommand := C.CString(command)
+	defer C.free(unsafe.Pointer(cCommand))
+	result := C.virDomainQemuMonitorCommand(d.ptr, cCommand, &cResult, C.uint(flags))
+
+	if result != 0 {
+		return "", GetLastError()
+	}
+
+	rstring := C.GoString(cResult)
+	C.free(unsafe.Pointer(cResult))
+	return rstring, nil
 }

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+func buildTestQEMUConnection() VirConnection {
+	conn, err := NewVirConnection("qemu:///system")
+	if err != nil {
+		panic(err)
+	}
+	return conn
+}
+
 func buildTestConnection() VirConnection {
 	conn, err := NewVirConnection("test:///default")
 	if err != nil {


### PR DESCRIPTION
@rgbkrk Review, please. 

This commit exposes the libvirt wrapper around QEMU Monitor Command support,
which proxies monitor commands through libvirt, including a supporting
test in domain_test.go.

The test uses a QEMU-based libvirt domain which has no state, so it should
compile fine (I hope) on anybody's system.

Comments welcome. =)