### PR TITLE
Adding events support for go 1.6

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -1,5 +1,3 @@
-//+build !go1.6
-
 package libvirt
 
 /*
@@ -9,7 +7,7 @@ package libvirt
  */
 
 /*
-#cgo LDFLAGS: -lvirt 
+#cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>
@@ -95,6 +93,17 @@ int domainEventDeviceRemovedCallback_cgo(virConnectPtr c, virDomainPtr d,
                                          const char *devAlias, void *data)
 {
     return domainEventDeviceRemovedCallback(c, d, devAlias, data);
+}
+
+void freeGoCallback_cgo(void* goCallbackId) {
+   freeCallbackId((size_t)goCallbackId);
+}
+
+int virConnectDomainEventRegisterAny_cgo(virConnectPtr c,  virDomainPtr d,
+						                             int eventID, virConnectDomainEventGenericCallback cb,
+                                         int goCallbackId) {
+    void* id = (void*)0 + goCallbackId; // Hack to silence the warning
+    return virConnectDomainEventRegisterAny(c, d, eventID, cb, id, freeGoCallback_cgo);
 }
 */
 import "C"

--- a/events_test.go
+++ b/events_test.go
@@ -1,5 +1,3 @@
-//+build !go1.6
-
 package libvirt
 
 import (
@@ -79,9 +77,24 @@ func TestDomainEventRegister(t *testing.T) {
 		}
 	}()
 
+	// Check that the internal context entry was added, and that there only is
+	// one.
+	goCallbackLock.Lock()
+	if len(goCallbacks) != 1 {
+		t.Error("goCallbacks should hold one entry")
+	}
+	goCallbackLock.Unlock()
+
 	// Deregister the event
 	if ret := conn.DomainEventDeregister(callbackId); ret < 0 {
 		t.Fatal("Event deregistration failed")
 	}
 	callbackId = -1 // Don't deregister twice
+
+	// Check that the internal context entries was removed
+	goCallbackLock.Lock()
+	if len(goCallbacks) > 0 {
+		t.Error("goCallbacks entry wasn't removed")
+	}
+	goCallbackLock.Unlock()
 }


### PR DESCRIPTION
So this might seem crazy to a C developer, but it could be the right way to do this.
Once you're past the hacks converting ints to pointers, it's probably the simplest way to this.

Basically, instead of passing pointers to C, we pass a integer id. Then we maintain a global map from integer ids to context objects.
Using a global mutex to locking access for the map, this pattern is safe.
The callback passed to C is just a static go function, which then finds the context object in the global map.

A C developer might question the sanity of using a hash map for resolving ids, when the ids are effectively pointers. But this seems like the simplest way to get static reference to an object in go.
I also suspect that most of these events are fairly low frequency, so efficiency probably isn't critical here (correct me I'm wrong).
If we wanted to make it faster, we could use an array instead of a map. Then we would have to search for an unused slot whenever we register an event handler (and we would be reusing callback ids).

By the way, in case anyone knows... Why does the callbacks returns an integer?
I don't see that in libvirt docs...

Note: I did some "interesting" integer casting here, I think it's sound, but it might be worth to do
a decent review.
We could also consider expanding the test case to ensure that entries in the `goCallbacks` tables are freed.

Anyways, let me know what you guys think. Should we consider something like this.