### PR TITLE
Add CreateWithFlags() for domain

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -102,6 +102,14 @@ func (d *VirDomain) Create() error {
 	return nil
 }
 
+func (d *VirDomain) CreateWithFlags(flags uint) error {
+	result := C.virDomainCreateWithFlags(d.ptr, C.uint(flags))
+	if result == -1 {
+		return GetLastError()
+	}
+	return nil
+}
+
 func (d *VirDomain) Destroy() error {
 	result := C.virDomainDestroy(d.ptr)
 	if result == -1 {

--- a/domain_test.go
+++ b/domain_test.go
@@ -612,3 +612,26 @@ func TestQemuMonitorCommand(t *testing.T) {
 		return
 	}
 }
+
+func TestDomainCreateWithFlags(t *testing.T) {
+	dom, conn := buildTestQEMUDomain()
+	defer func() {
+		dom.Undefine()
+		dom.Free()
+		conn.CloseConnection()
+	}()
+	if err := dom.CreateWithFlags(VIR_DOMAIN_START_PAUSED); err != nil {
+		t.Error(err)
+		return
+	}
+	defer dom.Destroy()
+	state, err := dom.GetState()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if state[0] != VIR_DOMAIN_PAUSED {
+		t.Fatalf("Domain should be paused")
+	}
+}
+


### PR DESCRIPTION
The test is using buildTestQEMUDomain() because the test driver does
not support other create flags besides VIR_DOMAIN_NONE.
domain.CreateWithFlags(VIR_DOMAIN_NONE) is the same as domain.Create()