### PR TITLE
Add method to enable setting ptr on VirConnection

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -72,6 +72,10 @@ func GetLastError() VirError {
 	return virErr
 }
 
+func (c *VirConnection) SetPtr(ptr unsafe.Pointer) {
+	c.ptr = C.virConnectPtr(ptr)
+}
+
 func (c *VirConnection) CloseConnection() (int, error) {
 	result := int(C.virConnectClose(c.ptr))
 	if result == -1 {


### PR DESCRIPTION
Since ptr is not exported, we need a function to allow it to be set
by another package.

Also, since the type of ptr is derived from C, other packages cannot
be cast to that type (C.virConnectPtr becomes libvirt.C.virConnectPtr)
- at least they could not as far as I could tell.

This function will solve both problems by being exported, and then
handling the type casting to C.virConnectPtr. This way someone can
just send us a pointer to the connection they created themselves,
and we can still use it in the library.

---

The reason I want to do this is because the [virConnectOpenAuth](https://libvirt.org/html/libvirt-libvirt-host.html#virConnectOpenAuth) function is not implemented in this package. I wanted to just implement that method here, but did not figure out how to handle types declared in C which get namespaced by the package - thereby preventing people from passing in their callback since it would not be of type `libvirt.C.virConnectPtr`.

So instead I just opened up VirConnection to allow me to implement the `virConnectOpenAuth` method in my other package, and then just set the resulting pointer in a `libvirt.VirConnection`. 