### PR TITLE
Remove outdated comments about Golang 1.6 and events

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -1,12 +1,6 @@
 package libvirt
 
 /*
- * Golang 1.6 doesn't support C pointers to go memory.
- * A hacky-solution might be some multi-threaded approach to support domain events, but let's make it work
- * without domain events for now.
- */
-
-/*
 #cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>

--- a/events.go
+++ b/events.go
@@ -6,12 +6,6 @@ import (
 )
 
 /*
- * Golang 1.6 doesn't support C pointers to go memory.
- * A hacky-solution might be some multi-threaded approach to support domain events, but let's make it work
- * without domain events for now.
- */
-
-/*
 #cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 


### PR DESCRIPTION
ba5e0139775a brought event support for Go 1.6. Some comments were left
and may lead people to believe that events are not supported. Remove
them.