### PR TITLE
Remove "implicit declaration of function" warning

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -1,6 +1,7 @@
 package libvirt
 
 /*
+#cgo CFLAGS: -Wno-implicit-function-declaration
 #cgo LDFLAGS: -lvirt
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>


### PR DESCRIPTION
Recent versions of gcc will complain about all the callbacks defined in
Go and called from C are undefined functions.

We cannot use the generated "_cgo_export.h" file because it is not
present yet. Introducing intermediary C functions that will call the Go
function from a separate .c file importing "_cgo_export.h" seems
overkill. Manual declaration of function prototypes is bothersome (and
would need to be checked). Use of C preprocessor may help a bit but
won't help in correctness as only the content of "_cgo_export.h"
matters.

Therefore, it just seems easier to ignore those warnings.