### PR TITLE
Promote goCallbackId to a C long

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -96,13 +96,13 @@ int domainEventDeviceRemovedCallback_cgo(virConnectPtr c, virDomainPtr d,
 }
 
 void freeGoCallback_cgo(void* goCallbackId) {
-   freeCallbackId((size_t)goCallbackId);
+   freeCallbackId((long)goCallbackId);
 }
 
 int virConnectDomainEventRegisterAny_cgo(virConnectPtr c,  virDomainPtr d,
-						                             int eventID, virConnectDomainEventGenericCallback cb,
-                                         int goCallbackId) {
-    void* id = (void*)0 + goCallbackId; // Hack to silence the warning
+                                         int eventID, virConnectDomainEventGenericCallback cb,
+                                         long goCallbackId) {
+    void* id = (void*)goCallbackId;
     return virConnectDomainEventRegisterAny(c, d, eventID, cb, id, freeGoCallback_cgo);
 }
 */

--- a/events.go
+++ b/events.go
@@ -60,8 +60,8 @@ int domainEventDeviceRemovedCallback_cgo(virConnectPtr c, virDomainPtr d,
                                          const char *devAlias, void* data);
 
 int virConnectDomainEventRegisterAny_cgo(virConnectPtr c,  virDomainPtr d,
-						                             int eventID, virConnectDomainEventGenericCallback cb,
-                                         int goCallbackId);
+                                         int eventID, virConnectDomainEventGenericCallback cb,
+                                         long goCallbackId);
 */
 import "C"
 
@@ -443,7 +443,7 @@ func (c *VirConnection) DomainEventRegister(dom VirDomain,
 	}
 	ret := C.virConnectDomainEventRegisterAny_cgo(c.ptr, dom.ptr, C.VIR_DOMAIN_EVENT_ID_LIFECYCLE,
 		C.virConnectDomainEventGenericCallback(callbackPtr),
-		C.int(goCallBackId))
+		C.long(goCallBackId))
 	if ret == -1 {
 		goCallbackLock.Lock()
 		delete(goCallbacks, goCallBackId)


### PR DESCRIPTION
On x86-64, GoInt is 64bit, therefore using int for goCallbackId
introduces a truncation. It is therefore safer to use a type that is as
large as expected. We cannot use something larger as on 32bit arch, long
long is bigger than void*. From a C perspective, this is something safe
as sizeof(long) == sizeof(void *) on almost [all archs][0].

The cast to void* is modified to be symmetric and safe. The unmodified
long is stored inside the pointer and is retrieved unmodified.

cc @jonasfj @hinesmr @rgbkrk as this relates to #69.

[0]: https://wiki.debian.org/ArchitectureSpecificsMemo#Summary