### PR TITLE
Return the C callbackId for virConnectDomainEventRegisterAny

### DIFF
--- a/events.go
+++ b/events.go
@@ -363,9 +363,10 @@ type domainCallbackContext struct {
 	f  func()
 }
 
+const firstGoCallbackId int = 100 // help catch some additional errors during test
 var goCallbackLock sync.RWMutex
 var goCallbacks = make(map[int]*domainCallbackContext)
-var nextGoCallbackId int
+var nextGoCallbackId int = firstGoCallbackId
 
 //export freeCallbackId
 func freeCallbackId(goCallbackId int) {
@@ -444,7 +445,7 @@ func (c *VirConnection) DomainEventRegister(dom VirDomain,
 		goCallbackLock.Unlock()
 		return -1
 	}
-	return goCallBackId
+	return int(ret)
 }
 
 func (c *VirConnection) DomainEventDeregister(callbackId int) int {

--- a/events_test.go
+++ b/events_test.go
@@ -12,7 +12,10 @@ func TestDomainEventRegister(t *testing.T) {
 	conn := buildTestConnection()
 	defer func() {
 		if callbackId >= 0 {
-			conn.DomainEventDeregister(callbackId)
+			ret := conn.DomainEventDeregister(callbackId)
+			if ret != 0 {
+				t.Errorf("got %d on DomainEventDeregister instead of 0", ret)
+			}
 		}
 		conn.CloseConnection()
 	}()


### PR DESCRIPTION
The callback ID to return is the one from C, to be used to deregister
the event. The test is modified to check the error. The initial
goCallbackId value is also modified to exhibit the error. This can be
dropped from this commit if it seems too odd.