### PR TITLE
Add SetKeepAlive() function to enable keepalive probes

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -496,6 +496,16 @@ func (c *VirConnection) LookupNetworkByUUIDString(uuid string) (VirNetwork, erro
 	return VirNetwork{ptr: ptr}, nil
 }
 
+func (c *VirConnection) SetKeepAlive(interval int, count uint) error {
+	res := int(C.virConnectSetKeepAlive(c.ptr, C.int(interval), C.uint(count)))
+	switch res {
+	case 0:
+		return nil
+	default:
+		return GetLastError()
+	}
+}
+
 func (c *VirConnection) GetSysinfo(flags uint) (string, error) {
 	cStr := C.virConnectGetSysinfo(c.ptr, C.uint(flags))
 	if cStr == nil {


### PR DESCRIPTION
The test needs a real QEMU connection as this feature is not supported
by the test driver. Also, the documentation mentions the return code is
-1 for generic errors and 1 if the remote end doesn't support
keepalives. However, a quick test shows that the test backend will just
return -1. virsh is just testing if the return code is different of
0. Therefore, it seems safer to trigger an error if return code != 0.