### PR TITLE
events: handle overflow of callback IDs

### DIFF
--- a/events.go
+++ b/events.go
@@ -401,6 +401,9 @@ func registerCallbackId(ctx interface{}) int {
 	goCallbackLock.Lock()
 	goCallBackId := nextGoCallbackId
 	nextGoCallbackId++
+	for goCallbacks[nextGoCallbackId] != nil {
+		nextGoCallbackId++
+	}
 	goCallbacks[goCallBackId] = ctx
 	goCallbackLock.Unlock()
 	return goCallBackId


### PR DESCRIPTION
When registering/deregistering a lot of callbacks, in a long-running
process, it may be possible for `nextGoCallbackId` to
overflow. Therefore, after incrementing it, check that its number is not
already used. This should be a rare event as the map should stay quite
sparse.