### PR TITLE
Error callbacks

### DIFF
--- a/cfuncs.go
+++ b/cfuncs.go
@@ -101,9 +101,22 @@ int virConnectDomainEventRegisterAny_cgo(virConnectPtr c,  virDomainPtr d,
     return virConnectDomainEventRegisterAny(c, d, eventID, cb, id, freeGoCallback_cgo);
 }
 
-void errorGlobalCallback_cgo(void *userData, virErrorPtr error) {
+void errorGlobalCallback_cgo(void *userData, virErrorPtr error)
+{
     globalErrorCallback(error);
 }
+
+void errorConnCallback_cgo(void *userData, virErrorPtr error)
+{
+    connErrorCallback((long)userData, error);
+}
+
+void virConnSetErrorFunc_cgo(virConnectPtr c, long goCallbackId, virErrorFunc cb)
+{
+    void* id = (void*)goCallbackId;
+    virConnSetErrorFunc(c, id, cb);
+}
+
 
 */
 import "C"

--- a/cfuncs.go
+++ b/cfuncs.go
@@ -100,5 +100,10 @@ int virConnectDomainEventRegisterAny_cgo(virConnectPtr c,  virDomainPtr d,
     void* id = (void*)goCallbackId;
     return virConnectDomainEventRegisterAny(c, d, eventID, cb, id, freeGoCallback_cgo);
 }
+
+void errorGlobalCallback_cgo(void *userData, virErrorPtr error) {
+    globalErrorCallback(error);
+}
+
 */
 import "C"

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,29 @@
+package libvirt
+
+import "testing"
+
+func TestGlobalErrorCallback(t *testing.T) {
+	var nbErrors int
+	errors := make([]VirError, 0, 10)
+	callback := ErrorCallback(func(err VirError, f func()) {
+		errors = append(errors, err)
+		f()
+	})
+	SetErrorFunc(callback, func() {
+		nbErrors++
+	})
+	NewVirConnection("invalid_transport:///default")
+	if len(errors) == 0 {
+		t.Errorf("No errors were captured")
+	}
+	if len(errors) != nbErrors {
+		t.Errorf("Captured %d errors (%+v) but counted only %d errors",
+			len(errors), errors, nbErrors)
+	}
+	errors = make([]VirError, 0, 10)
+	SetErrorFunc(nil, nil)
+	NewVirConnection("invalid_transport:///default")
+	if len(errors) != 0 {
+		t.Errorf("More errors have been captured: %+v", errors)
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -27,3 +27,47 @@ func TestGlobalErrorCallback(t *testing.T) {
 		t.Errorf("More errors have been captured: %+v", errors)
 	}
 }
+
+func TestConnectionErrorCallback(t *testing.T) {
+	var nbErrors int
+	errors := make([]VirError, 0, 10)
+	callback := ErrorCallback(func(err VirError, f func()) {
+		errors = append(errors, err)
+		f()
+	})
+	conn := buildTestConnection()
+	conn.SetErrorFunc(callback, func() {
+		nbErrors++
+	})
+	defer conn.UnsetErrorFunc()
+
+	// To generate an error, we set memory of a domain to an insance value
+	domain, err := conn.LookupDomainByName("test")
+	if err != nil {
+		panic(err)
+	}
+	err = domain.SetMemory(100000000000)
+	if err == nil {
+		t.Fatalf("Was expecting an error when setting memory to too high value")
+	}
+
+	if len(errors) == 0 {
+		t.Errorf("No errors were captured")
+	}
+	if len(errors) != nbErrors {
+		t.Errorf("Captured %d errors (%+v) but counted only %d errors",
+			len(errors), errors, nbErrors)
+	}
+	errors = make([]VirError, 0, 10)
+	conn.UnsetErrorFunc()
+	if len(goCallbacks) != 0 {
+		t.Errorf("goCallbacks entry wasn't removed: %+v", goCallbacks)
+	}
+	err = domain.SetMemory(100000000000)
+	if err == nil {
+		t.Fatalf("Was expecting an error when setting memory to too high value")
+	}
+	if len(errors) != 0 {
+		t.Errorf("More errors have been captured: %+v", errors)
+	}
+}

--- a/events.go
+++ b/events.go
@@ -375,8 +375,7 @@ func freeCallbackId(goCallbackId int) {
 	goCallbackLock.Unlock()
 }
 
-func callDomainCallbackId(goCallbackId int, c *VirConnection, d *VirDomain,
-	event interface{}) int {
+func getCallbackId(goCallbackId int) interface{} {
 	goCallbackLock.RLock()
 	ctx := goCallbacks[goCallbackId]
 	goCallbackLock.RUnlock()
@@ -384,6 +383,12 @@ func callDomainCallbackId(goCallbackId int, c *VirConnection, d *VirDomain,
 		// If this happens there must be a bug in libvirt
 		panic("Callback arrived after freeCallbackId was called")
 	}
+	return ctx
+}
+
+func callDomainCallbackId(goCallbackId int, c *VirConnection, d *VirDomain,
+	event interface{}) int {
+	ctx := getCallbackId(goCallbackId)
 	switch cctx := ctx.(type) {
 	case *domainCallbackContext:
 		return (*cctx.cb)(c, d, event, cctx.f)

--- a/events_test.go
+++ b/events_test.go
@@ -84,7 +84,7 @@ func TestDomainEventRegister(t *testing.T) {
 	// one.
 	goCallbackLock.Lock()
 	if len(goCallbacks) != 1 {
-		t.Error("goCallbacks should hold one entry")
+		t.Errorf("goCallbacks should hold one entry, got %+v", goCallbacks)
 	}
 	goCallbackLock.Unlock()
 
@@ -97,7 +97,7 @@ func TestDomainEventRegister(t *testing.T) {
 	// Check that the internal context entries was removed
 	goCallbackLock.Lock()
 	if len(goCallbacks) > 0 {
-		t.Error("goCallbacks entry wasn't removed")
+		t.Errorf("goCallbacks entry wasn't removed: %+v", goCallbacks)
 	}
 	goCallbackLock.Unlock()
 }

--- a/libvirt.go
+++ b/libvirt.go
@@ -16,7 +16,8 @@ import (
 import "C"
 
 type VirConnection struct {
-	ptr C.virConnectPtr
+	ptr           C.virConnectPtr
+	errCallbackId *int
 }
 
 func NewVirConnection(uri string) (VirConnection, error) {
@@ -59,6 +60,7 @@ func (c *VirConnection) SetPtr(ptr unsafe.Pointer) {
 }
 
 func (c *VirConnection) CloseConnection() (int, error) {
+	c.UnsetErrorFunc()
 	result := int(C.virConnectClose(c.ptr))
 	if result == -1 {
 		return result, GetLastError()

--- a/libvirt.go
+++ b/libvirt.go
@@ -12,20 +12,8 @@ import (
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 #include <stdlib.h>
-
-void virErrorFuncDummy(void *userData, virErrorPtr error);
-
-void virErrorFuncDummy(void *userData, virErrorPtr error)
-{
-}
-
 */
 import "C"
-
-func init() {
-	// libvirt won't print to stderr
-	C.virSetErrorFunc(nil, C.virErrorFunc(unsafe.Pointer(C.virErrorFuncDummy)))
-}
 
 type VirConnection struct {
 	ptr C.virConnectPtr
@@ -60,14 +48,8 @@ func NewVirConnectionReadOnly(uri string) (VirConnection, error) {
 }
 
 func GetLastError() VirError {
-	var virErr VirError
 	err := C.virGetLastError()
-
-	virErr.Code = int(err.code)
-	virErr.Domain = int(err.domain)
-	virErr.Message = C.GoString(err.message)
-	virErr.Level = int(err.level)
-
+	virErr := newError(err)
 	C.virResetError(err)
 	return virErr
 }


### PR DESCRIPTION
Hey!

This PR enables one to setup error callbacks. The second commit implements `virSetErrorFunc()` function which sets the global error callback. This is the most useful one. We keep the default to silent stderr.

The first commit is taken from #94 and is needed for the last one. The last commit implements `virConnSetErrorFunc()`. However, since without it, errors are passed to the global handlers, it is not that useful. We could discard the first and last commit of this PR if this seems too invasive. Note however that by default, there is no handler and therefore the last commit will only impact users of this feature. So, it should be safe.

Moreover, I will need the first commit for another PR (close callbacks).