### PR TITLE
connection: remove dangerous SetPtr() and UnrefAndCloseConnection() methods

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -55,10 +55,6 @@ func GetLastError() VirError {
 	return virErr
 }
 
-func (c *VirConnection) SetPtr(ptr unsafe.Pointer) {
-	c.ptr = C.virConnectPtr(ptr)
-}
-
 func (c *VirConnection) CloseConnection() (int, error) {
 	c.UnsetErrorFunc()
 	result := int(C.virConnectClose(c.ptr))
@@ -66,18 +62,6 @@ func (c *VirConnection) CloseConnection() (int, error) {
 		return result, GetLastError()
 	}
 	return result, nil
-}
-
-func (c *VirConnection) UnrefAndCloseConnection() error {
-	closeRes := 1
-	var err error
-	for closeRes > 0 {
-		closeRes, err = c.CloseConnection()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *VirConnection) GetCapabilities() (string, error) {


### PR DESCRIPTION
Those two changes break the API backward compatibility! I do this PR to see how others feel about those functions.

The first function was introduced in #81 to workaround the absence of
virConnectOpenAuth() method. This defeats the purpose of having an
opaque structure for a connection. Now that there is a mechanism to
handle callbacks, it should be easier to implement virConnectOpenAuth()
correctly.

The second function should not exist as there is no way to increment
reference of an existing connection from Go code (virConnectRef() is not
implemented). Therefore, if this function was needed, this should be
because the C code increments a reference to a connection but the
appropriate call to decrement it is absent. For example, we requested a
domain but we didn't free it. Therefore, the domain holds a reference to
the connection and the connection is not closed correctly. Forcing the
connection to close implies there is a leak somewhere (the domain should
be freed).