### PR TITLE
test: ensure we don't have any connection leak

### DIFF
--- a/domain_1.2.14_test.go
+++ b/domain_1.2.14_test.go
@@ -10,7 +10,9 @@ func TestDomainListAllInterfaceAddresses(t *testing.T) {
 	dom, conn := buildTestQEMUDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)

--- a/domain_test.go
+++ b/domain_test.go
@@ -54,7 +54,9 @@ func TestUndefineDomain(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	name, err := dom.GetName()
 	if err != nil {
@@ -76,7 +78,9 @@ func TestGetDomainName(t *testing.T) {
 	defer func() {
 		dom.Undefine()
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := dom.GetName(); err != nil {
 		t.Error(err)
@@ -88,7 +92,9 @@ func TestGetDomainState(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	state, err := dom.GetState()
 	if err != nil {
@@ -109,7 +115,9 @@ func TestGetDomainID(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	if err := dom.Create(); err != nil {
@@ -128,7 +136,9 @@ func TestGetDomainUUID(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := dom.GetUUID()
 	// how to test uuid validity?
@@ -142,7 +152,9 @@ func TestGetDomainUUIDString(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := dom.GetUUIDString()
 	if err != nil {
@@ -155,7 +167,9 @@ func TestGetDomainInfo(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := dom.GetInfo()
 	if err != nil {
@@ -168,7 +182,9 @@ func TestGetDomainXMLDesc(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := dom.GetXMLDesc(0)
 	if err != nil {
@@ -181,7 +197,9 @@ func TestCreateDomainSnapshotXML(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	ss, err := dom.CreateSnapshotXML(`
 		<domainsnapshot>
@@ -199,7 +217,9 @@ func TestSaveDomain(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	// get the name so we can get a handle on it later
 	domName, err := dom.GetName()
@@ -216,9 +236,11 @@ func TestSaveDomain(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if _, err = conn.LookupDomainByName(domName); err != nil {
+	if dom2, err := conn.LookupDomainByName(domName); err != nil {
 		t.Error(err)
 		return
+	} else {
+		dom2.Free()
 	}
 }
 
@@ -226,7 +248,9 @@ func TestSaveDomainFlags(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	const srcFile = "/tmp/libvirt-go-test.tmp"
 	if err := dom.SaveFlags(srcFile, "", 0); err == nil {
@@ -239,7 +263,9 @@ func TestCreateDestroyDomain(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -271,7 +297,12 @@ func TestCreateDestroyDomain(t *testing.T) {
 
 func TestShutdownDomain(t *testing.T) {
 	dom, conn := buildTestDomain()
-	defer conn.CloseConnection()
+	defer func() {
+		dom.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
 		return
@@ -295,7 +326,9 @@ func TestShutdownReboot(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Reboot(0); err != nil {
 		t.Error(err)
@@ -307,7 +340,9 @@ func TestDomainAutostart(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	as, err := dom.GetAutostart()
 	if err != nil {
@@ -337,7 +372,9 @@ func TestDomainIsActive(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Log(err)
@@ -372,9 +409,13 @@ func TestDomainIsPersistent(t *testing.T) {
 	dom2, conn2 := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
 		dom2.Free()
-		conn2.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+		if res, _ := conn2.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	persistent, err := dom.IsPersistent()
 	if err != nil {
@@ -401,7 +442,9 @@ func TestDomainSetMaxMemory(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.SetMaxMemory(mem); err != nil {
 		t.Error(err)
@@ -413,7 +456,9 @@ func TestDomainSetMemory(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -429,7 +474,9 @@ func TestDomainSetVcpus(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -447,7 +494,11 @@ func TestDomainSetVcpus(t *testing.T) {
 
 func TestDomainFree(t *testing.T) {
 	dom, conn := buildTestDomain()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := dom.Free(); err != nil {
 		t.Error(err)
 		return
@@ -458,7 +509,9 @@ func TestDomainSuspend(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -474,7 +527,11 @@ func TestDomainSuspend(t *testing.T) {
 
 func TesDomainShutdownFlags(t *testing.T) {
 	dom, conn := buildTestDomain()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
 		return
@@ -496,7 +553,11 @@ func TesDomainShutdownFlags(t *testing.T) {
 
 func TesDomainDestoryFlags(t *testing.T) {
 	dom, conn := buildTestDomain()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
 		return
@@ -520,7 +581,9 @@ func TestDomainScreenshot(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -544,7 +607,9 @@ func TestDomainGetVcpus(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -570,7 +635,9 @@ func TestDomainGetVcpusFlags(t *testing.T) {
 	dom, conn := buildTestDomain()
 	defer func() {
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := dom.Create(); err != nil {
 		t.Error(err)
@@ -594,7 +661,9 @@ func TestQemuMonitorCommand(t *testing.T) {
 		dom.Destroy()
 		dom.Undefine()
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	if err := dom.Create(); err != nil {
@@ -616,9 +685,12 @@ func TestQemuMonitorCommand(t *testing.T) {
 func TestDomainCreateWithFlags(t *testing.T) {
 	dom, conn := buildTestQEMUDomain()
 	defer func() {
+		dom.Destroy()
 		dom.Undefine()
 		dom.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	if err := dom.CreateWithFlags(VIR_DOMAIN_START_PAUSED); err != nil {

--- a/error_test.go
+++ b/error_test.go
@@ -35,7 +35,14 @@ func TestConnectionErrorCallback(t *testing.T) {
 		errors = append(errors, err)
 		f()
 	})
+
 	conn := buildTestConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
+
 	conn.SetErrorFunc(callback, func() {
 		nbErrors++
 	})
@@ -46,6 +53,7 @@ func TestConnectionErrorCallback(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer domain.Free()
 	err = domain.SetMemory(100000000000)
 	if err == nil {
 		t.Fatalf("Was expecting an error when setting memory to too high value")

--- a/events_test.go
+++ b/events_test.go
@@ -17,7 +17,9 @@ func TestDomainEventRegister(t *testing.T) {
 				t.Errorf("got %d on DomainEventDeregister instead of 0", ret)
 			}
 		}
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	nodom := VirDomain{}

--- a/integration_test.go
+++ b/integration_test.go
@@ -42,7 +42,11 @@ func TestIntegrationGetMetadata(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	title := time.Now().String()
 	dom, err := defineTestLxcDomain(conn, title)
 	if err != nil {
@@ -76,7 +80,11 @@ func TestIntegrationSetMetadata(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {
 		t.Error(err)
@@ -108,7 +116,11 @@ func TestIntegrationGetSysinfo(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	info, err := conn.GetSysinfo(0)
 	if err != nil {
 		t.Error(err)
@@ -138,7 +150,11 @@ func TestIntergrationDefineUndefineNWFilterXML(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML("", "ipv4"))
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +177,11 @@ func TestIntegrationNWFilterGetName(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML("", "ipv4"))
 	if err != nil {
 		t.Error(err)
@@ -182,7 +202,11 @@ func TestIntegrationNWFilterGetUUID(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML("", "ipv4"))
 	if err != nil {
 		t.Error(err)
@@ -203,7 +227,11 @@ func TestIntegrationNWFilterGetUUIDString(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML("", "ipv4"))
 	if err != nil {
 		t.Error(err)
@@ -224,7 +252,11 @@ func TestIntegrationNWFilterGetXMLDesc(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML("", "ipv4"))
 	if err != nil {
 		t.Error(err)
@@ -245,7 +277,11 @@ func TestIntegrationLookupNWFilterByName(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	origName := time.Now().String()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML(origName, "ipv4"))
 	if err != nil {
@@ -256,13 +292,14 @@ func TestIntegrationLookupNWFilterByName(t *testing.T) {
 		filter.Undefine()
 		filter.Free()
 	}()
-	filter, err = conn.LookupNWFilterByName(origName)
+	filter2, err := conn.LookupNWFilterByName(origName)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer filter2.Free()
 	var newName string
-	newName, err = filter.GetName()
+	newName, err = filter2.GetName()
 	if err != nil {
 		t.Error(err)
 		return
@@ -278,7 +315,11 @@ func TestIntegrationLookupNWFilterByUUIDString(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	origName := time.Now().String()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML(origName, "ipv4"))
 	if err != nil {
@@ -289,23 +330,25 @@ func TestIntegrationLookupNWFilterByUUIDString(t *testing.T) {
 		filter.Undefine()
 		filter.Free()
 	}()
-	filter, err = conn.LookupNWFilterByName(origName)
+	filter2, err := conn.LookupNWFilterByName(origName)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer filter2.Free()
 	var filterUUID string
-	filterUUID, err = filter.GetUUIDString()
+	filterUUID, err = filter2.GetUUIDString()
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	filter, err = conn.LookupNWFilterByUUIDString(filterUUID)
+	filter3, err := conn.LookupNWFilterByUUIDString(filterUUID)
+	defer filter3.Free()
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	name, err := filter.GetName()
+	name, err := filter3.GetName()
 	if err != nil {
 		t.Error(err)
 		return
@@ -321,7 +364,11 @@ func TestIntegrationDomainAttachDetachDevice(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {
@@ -353,7 +400,11 @@ func TestStorageVolResize(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	poolPath, err := ioutil.TempDir("", "default-pool-test-1")
 	if err != nil {
@@ -397,7 +448,11 @@ func TestStorageVolWipe(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	poolPath, err := ioutil.TempDir("", "default-pool-test-1")
 	if err != nil {
@@ -440,7 +495,11 @@ func TestStorageVolWipePattern(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	poolPath, err := ioutil.TempDir("", "default-pool-test-1")
 	if err != nil {
@@ -497,7 +556,11 @@ func TestIntegrationSecretDefineUndefine(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(""), 0)
 	if err != nil {
 		t.Fatal(err)
@@ -515,7 +578,11 @@ func TestIntegrationSecretGetUUID(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(""), 0)
 	if err != nil {
 		t.Error(err)
@@ -536,7 +603,11 @@ func TestIntegrationSecretGetUUIDString(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(""), 0)
 	if err != nil {
 		t.Error(err)
@@ -557,7 +628,11 @@ func TestIntegrationSecretGetXMLDesc(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(""), 0)
 	if err != nil {
 		t.Error(err)
@@ -578,7 +653,11 @@ func TestIntegrationSecretGetUsageType(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(""), 0)
 	if err != nil {
 		t.Error(err)
@@ -604,7 +683,11 @@ func TestIntegrationSecretGetUsageID(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	setUsageID := time.Now().String()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(setUsageID), 0)
 	if err != nil {
@@ -631,7 +714,11 @@ func TestIntegrationLookupSecretByUsage(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	usageID := time.Now().String()
 	sec, err := conn.SecretDefineXML(testSecretTypeCephFromXML(usageID), 0)
 	if err != nil {
@@ -642,10 +729,11 @@ func TestIntegrationLookupSecretByUsage(t *testing.T) {
 		sec.Undefine()
 		sec.Free()
 	}()
-	sec, err = conn.LookupSecretByUsage(VIR_SECRET_USAGE_TYPE_CEPH, usageID)
+	sec2, err := conn.LookupSecretByUsage(VIR_SECRET_USAGE_TYPE_CEPH, usageID)
 	if err != nil {
 		t.Fatal(err)
 	}
+	sec2.Free()
 }
 
 func TestIntegrationGetDomainCPUStats(t *testing.T) {
@@ -653,7 +741,11 @@ func TestIntegrationGetDomainCPUStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {
 		t.Fatal(err)
@@ -714,7 +806,9 @@ func TestIntegrationGetDomainCPUStats(t *testing.T) {
 // 	defer func() {
 // 		dom.Undefine()
 // 		dom.Free()
-// 		conn.CloseConnection()
+// 		if res, _ := conn.CloseConnection(); res != 0 {
+// 			t.Errorf("CloseConnection() == %d, expected 0", res)
+// 		}
 // 	}()
 // 	iface := "either mac or path to interface"
 // 	nparams := int(0)
@@ -736,7 +830,11 @@ func TestIntegrationListAllInterfaces(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	ifaces, err := conn.ListAllInterfaces(0)
 	if err != nil {
 		t.Fatal(err)
@@ -764,7 +862,11 @@ func TestIntergrationListAllNWFilters(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	testNWFilterName := time.Now().String()
 	filter, err := conn.NWFilterDefineXML(testNWFilterXML(testNWFilterName, "ipv4"))
@@ -800,7 +902,11 @@ func TestIntegrationDomainBlockStatsFlags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {
@@ -828,7 +934,11 @@ func TestIntegrationDomainInterfaceStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {
@@ -870,7 +980,11 @@ func TestStorageVolUploadDownload(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	poolPath, err := ioutil.TempDir("", "default-pool-test-1")
 	if err != nil {
@@ -967,7 +1081,11 @@ func TestStorageVolUploadDownload(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	dom, err := defineTestLxcDomain(conn, "")
 	if err != nil {

--- a/interface_test.go
+++ b/interface_test.go
@@ -26,8 +26,12 @@ func generateRandomMac() string {
 
 func TestCreateDestroyInterface(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer iface.Free()
-	defer conn.CloseConnection()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := iface.Create(0); err != nil {
 		t.Error(err)
 		return
@@ -39,8 +43,12 @@ func TestCreateDestroyInterface(t *testing.T) {
 
 func TestUndefineInterface(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer iface.Free()
-	defer conn.CloseConnection()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	name, err := iface.GetName()
 	if err != nil {
 		t.Error(err)
@@ -57,8 +65,12 @@ func TestUndefineInterface(t *testing.T) {
 
 func TestGetInterfaceName(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer iface.Free()
-	defer conn.CloseConnection()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := iface.GetName(); err != nil {
 		t.Fatal(err)
 	}
@@ -66,8 +78,12 @@ func TestGetInterfaceName(t *testing.T) {
 
 func TestInterfaceIsActive(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer iface.Free()
-	defer conn.CloseConnection()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := iface.Create(0); err != nil {
 		t.Log(err)
 		return
@@ -97,8 +113,12 @@ func TestInterfaceIsActive(t *testing.T) {
 func TestGetMACString(t *testing.T) {
 	origMac := generateRandomMac()
 	iface, conn := buildTestInterface(origMac)
-	defer iface.Free()
-	defer conn.CloseConnection()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	mac, err := iface.GetMACString()
 	if err != nil {
 		t.Error(err)
@@ -111,8 +131,12 @@ func TestGetMACString(t *testing.T) {
 
 func TestGetInterfaceXMLDesc(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer conn.CloseConnection()
-	defer iface.Free()
+	defer func() {
+		iface.Free()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := iface.GetXMLDesc(0); err != nil {
 		t.Error(err)
 	}
@@ -120,7 +144,11 @@ func TestGetInterfaceXMLDesc(t *testing.T) {
 
 func TestInterfaceFree(t *testing.T) {
 	iface, conn := buildTestInterface(generateRandomMac())
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := iface.Free(); err != nil {
 		t.Error(err)
 		return

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -27,10 +27,13 @@ func TestConnection(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = conn.CloseConnection()
+	res, err := conn.CloseConnection()
 	if err != nil {
 		t.Error(err)
 		return
+	}
+	if res != 0 {
+		t.Errorf("CloseConnection() == %d, expected 0", res)
 	}
 }
 
@@ -40,7 +43,11 @@ func TestConnectionReadOnly(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 
 	_, err = conn.NetworkDefineXML(`<network>
     <name>` + time.Now().String() + `</name>
@@ -63,7 +70,11 @@ func TestInvalidConnection(t *testing.T) {
 
 func TestGetType(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	tp, err := conn.GetType()
 	if err != nil {
 		t.Error(err)
@@ -78,7 +89,11 @@ func TestGetType(t *testing.T) {
 func TestSetKeepalive(t *testing.T) {
 	EventRegisterDefaultImpl()        // We need the event loop for keepalive
 	conn := buildTestQEMUConnection() // The test driver doesn't support keepalives
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := conn.SetKeepAlive(1, 1); err != nil {
 		t.Error(err)
 		return
@@ -100,7 +115,11 @@ func TestSetKeepalive(t *testing.T) {
 
 func TestIsAlive(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	alive, err := conn.IsAlive()
 	if err != nil {
 		t.Error(err)
@@ -114,7 +133,11 @@ func TestIsAlive(t *testing.T) {
 
 func TestIsEncryptedAndSecure(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	secure, err := conn.IsSecure()
 	if err != nil {
 		t.Log(err)
@@ -137,7 +160,11 @@ func TestIsEncryptedAndSecure(t *testing.T) {
 
 func TestCapabilities(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	capabilities, err := conn.GetCapabilities()
 	if err != nil {
 		t.Error(err)
@@ -151,7 +178,11 @@ func TestCapabilities(t *testing.T) {
 
 func TestGetNodeInfo(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	ni, err := conn.GetNodeInfo()
 	if err != nil {
 		t.Error(err)
@@ -165,7 +196,11 @@ func TestGetNodeInfo(t *testing.T) {
 
 func TestHostname(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	hostname, err := conn.GetHostname()
 	if err != nil {
 		t.Error(err)
@@ -179,7 +214,11 @@ func TestHostname(t *testing.T) {
 
 func TestLibVersion(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	version, err := conn.GetLibVersion()
 	if err != nil {
 		t.Error(err)
@@ -193,7 +232,11 @@ func TestLibVersion(t *testing.T) {
 
 func TestListDefinedDomains(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	doms, err := conn.ListDefinedDomains()
 	if err != nil {
 		t.Error(err)
@@ -207,7 +250,11 @@ func TestListDefinedDomains(t *testing.T) {
 
 func TestListDomains(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	doms, err := conn.ListDomains()
 	if err != nil {
 		t.Error(err)
@@ -221,7 +268,11 @@ func TestListDomains(t *testing.T) {
 
 func TestListInterfaces(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListInterfaces()
 	if err != nil {
 		t.Error(err)
@@ -231,7 +282,11 @@ func TestListInterfaces(t *testing.T) {
 
 func TestListNetworks(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListNetworks()
 	if err != nil {
 		t.Error(err)
@@ -241,7 +296,11 @@ func TestListNetworks(t *testing.T) {
 
 func TestListStoragePools(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListStoragePools()
 	if err != nil {
 		t.Error(err)
@@ -251,7 +310,11 @@ func TestListStoragePools(t *testing.T) {
 
 func TestLookupDomainById(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	ids, err := conn.ListDomains()
 	if err != nil {
 		t.Error(err)
@@ -272,12 +335,21 @@ func TestLookupDomainById(t *testing.T) {
 
 func TestLookupDomainByUUIDString(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	doms, err := conn.ListAllDomains(0)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer func() {
+		for _, dom := range doms {
+			dom.Free()
+		}
+	}()
 	t.Log(doms)
 	if len(doms) == 0 {
 		t.Fatal("Length of ListAllDomains shouldn't be empty")
@@ -298,7 +370,11 @@ func TestLookupDomainByUUIDString(t *testing.T) {
 
 func TestLookupInvalidDomainById(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.LookupDomainById(12345)
 	if err == nil {
 		t.Error("Domain #12345 shouldn't exist in test transport")
@@ -308,7 +384,11 @@ func TestLookupInvalidDomainById(t *testing.T) {
 
 func TestLookupDomainByName(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	dom, err := conn.LookupDomainByName("test")
 	if err != nil {
 		t.Error(err)
@@ -319,7 +399,11 @@ func TestLookupDomainByName(t *testing.T) {
 
 func TestLookupInvalidDomainByName(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.LookupDomainByName("non_existent_domain")
 	if err == nil {
 		t.Error("Could find non-existent domain by name")
@@ -330,7 +414,11 @@ func TestLookupInvalidDomainByName(t *testing.T) {
 func TestDomainCreateXML(t *testing.T) {
 	conn := buildTestConnection()
 	nodom := VirDomain{}
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	// Test a minimally valid xml
 	defName := time.Now().String()
 	xml := `<domain type="test">
@@ -346,10 +434,8 @@ func TestDomainCreateXML(t *testing.T) {
 		return
 	}
 	defer func() {
-		if dom != nodom {
-			dom.Destroy()
-			dom.Free()
-		}
+		dom.Destroy()
+		dom.Free()
 	}()
 	name, err := dom.GetName()
 	if err != nil {
@@ -366,18 +452,22 @@ func TestDomainCreateXML(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	dom = nodom
 
 	testeddom, err := conn.LookupDomainByName(defName)
 	if testeddom != nodom {
 		t.Fatal("Created domain is persisting")
 		return
 	}
+	testeddom.Free()
 }
 
 func TestDomainDefineXML(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	// Test a minimally valid xml
 	defName := time.Now().String()
 	xml := `<domain type="test">
@@ -416,7 +506,11 @@ func TestDomainDefineXML(t *testing.T) {
 
 func TestListDefinedInterfaces(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListDefinedInterfaces()
 	if err != nil {
 		t.Error(err)
@@ -426,7 +520,11 @@ func TestListDefinedInterfaces(t *testing.T) {
 
 func TestListDefinedNetworks(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListDefinedNetworks()
 	if err != nil {
 		t.Error(err)
@@ -436,7 +534,11 @@ func TestListDefinedNetworks(t *testing.T) {
 
 func TestListDefinedStoragePools(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.ListDefinedStoragePools()
 	if err != nil {
 		t.Error(err)
@@ -446,7 +548,11 @@ func TestListDefinedStoragePools(t *testing.T) {
 
 func TestNumOfDefinedInterfaces(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfDefinedInterfaces(); err != nil {
 		t.Error(err)
 		return
@@ -455,7 +561,11 @@ func TestNumOfDefinedInterfaces(t *testing.T) {
 
 func TestNumOfDefinedNetworks(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfDefinedNetworks(); err != nil {
 		t.Error(err)
 		return
@@ -464,7 +574,11 @@ func TestNumOfDefinedNetworks(t *testing.T) {
 
 func TestNumOfDefinedStoragePools(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfDefinedStoragePools(); err != nil {
 		t.Error(err)
 		return
@@ -473,7 +587,11 @@ func TestNumOfDefinedStoragePools(t *testing.T) {
 
 func TestNumOfDomains(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfDomains(); err != nil {
 		t.Error(err)
 		return
@@ -482,7 +600,11 @@ func TestNumOfDomains(t *testing.T) {
 
 func TestNumOfInterfaces(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfInterfaces(); err != nil {
 		t.Error(err)
 		return
@@ -491,7 +613,11 @@ func TestNumOfInterfaces(t *testing.T) {
 
 func TestNumOfNetworks(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfNetworks(); err != nil {
 		t.Error(err)
 		return
@@ -500,7 +626,11 @@ func TestNumOfNetworks(t *testing.T) {
 
 func TestNumOfNWFilters(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfNWFilters(); err == nil {
 		t.Fatalf("NumOfNWFilters should fail due to no support on test driver")
 		return
@@ -509,7 +639,11 @@ func TestNumOfNWFilters(t *testing.T) {
 
 func TestNumOfSecrets(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if _, err := conn.NumOfSecrets(); err == nil {
 		t.Fatalf("NumOfSecrets should fail due to no support on test driver")
 		return
@@ -518,7 +652,11 @@ func TestNumOfSecrets(t *testing.T) {
 
 func TestGetURI(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	uri, err := conn.GetURI()
 	if err != nil {
 		t.Error(err)
@@ -531,7 +669,11 @@ func TestGetURI(t *testing.T) {
 
 func TestGetMaxVcpus(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	_, err := conn.GetMaxVcpus("")
 	if err != nil {
 		t.Error(err)
@@ -540,14 +682,21 @@ func TestGetMaxVcpus(t *testing.T) {
 
 func TestInterfaceDefineXML(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	defName := "ethTest0"
 	xml := `<interface type='ethernet' name='` + defName + `'><mac address='` + generateRandomMac() + `'/></interface>`
 	iface, err := conn.InterfaceDefineXML(xml, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer iface.Undefine()
+	defer func() {
+		iface.Undefine()
+		iface.Free()
+	}()
 	name, err := iface.GetName()
 	if err != nil {
 		t.Error(err)
@@ -568,13 +717,18 @@ func TestInterfaceDefineXML(t *testing.T) {
 
 func TestLookupInterfaceByName(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	testEth := "eth1"
 	iface, err := conn.LookupInterfaceByName(testEth)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer iface.Free()
 	var ifName string
 	ifName, err = iface.GetName()
 	if err != nil {
@@ -588,13 +742,18 @@ func TestLookupInterfaceByName(t *testing.T) {
 
 func TestLookupInterfaceByMACString(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	testMAC := "aa:bb:cc:dd:ee:ff"
 	iface, err := conn.LookupInterfaceByMACString(testMAC)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	defer iface.Free()
 	var ifMAC string
 	ifMAC, err = iface.GetMACString()
 	if err != nil {
@@ -608,7 +767,11 @@ func TestLookupInterfaceByMACString(t *testing.T) {
 
 func TestStoragePoolDefineXML(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	defName := "default-pool-test-0"
 	xml := `<pool type='dir'><name>default-pool-test-0</name><target>
             <path>/default-pool</path></target></pool>`
@@ -639,7 +802,11 @@ func TestStoragePoolDefineXML(t *testing.T) {
 
 func TestLookupStoragePoolByName(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	testPool := "default-pool"
 	pool, err := conn.LookupStoragePoolByName(testPool)
 	if err != nil {
@@ -660,7 +827,11 @@ func TestLookupStoragePoolByName(t *testing.T) {
 
 func TestLookupStoragePoolByUUIDString(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	poolName := "default-pool"
 	pool, err := conn.LookupStoragePoolByName(poolName)
 	if err != nil {
@@ -674,12 +845,13 @@ func TestLookupStoragePoolByUUIDString(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	pool, err = conn.LookupStoragePoolByUUIDString(poolUUID)
+	pool2, err := conn.LookupStoragePoolByUUIDString(poolUUID)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	name, err := pool.GetName()
+	defer pool2.Free()
+	name, err := pool2.GetName()
 	if err != nil {
 		t.Error(err)
 	}
@@ -693,7 +865,9 @@ func TestLookupStorageVolByKey(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -712,12 +886,13 @@ func TestLookupStorageVolByKey(t *testing.T) {
 		vol.Delete(VIR_STORAGE_VOL_DELETE_NORMAL)
 		vol.Free()
 	}()
-	vol, err = conn.LookupStorageVolByKey(defVolKey)
+	vol2, err := conn.LookupStorageVolByKey(defVolKey)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	key, err := vol.GetKey()
+	defer vol2.Free()
+	key, err := vol2.GetKey()
 	if err != nil {
 		t.Error(err)
 		return
@@ -732,7 +907,9 @@ func TestLookupStorageVolByPath(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -751,12 +928,13 @@ func TestLookupStorageVolByPath(t *testing.T) {
 		vol.Delete(VIR_STORAGE_VOL_DELETE_NORMAL)
 		vol.Free()
 	}()
-	vol, err = conn.LookupStorageVolByPath(defVolPath)
+	vol2, err := conn.LookupStorageVolByPath(defVolPath)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	path, err := vol.GetPath()
+	defer vol2.Free()
+	path, err := vol2.GetPath()
 	if err != nil {
 		t.Error(err)
 		return
@@ -768,7 +946,11 @@ func TestLookupStorageVolByPath(t *testing.T) {
 
 func TestListAllDomains(t *testing.T) {
 	conn := buildTestConnection()
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	doms, err := conn.ListAllDomains(VIR_CONNECT_LIST_DOMAINS_PERSISTENT)
 	if err != nil {
 		t.Error(err)
@@ -800,7 +982,9 @@ func TestListAllNetworks(t *testing.T) {
 		// the test connection is closed
 		net.Destroy()
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	nets, err := conn.ListAllNetworks(VIR_CONNECT_LIST_NETWORKS_INACTIVE)
 	if err != nil {
@@ -828,7 +1012,9 @@ func TestListAllStoragePools(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	pools, err := conn.ListAllStoragePools(VIR_STORAGE_POOL_INACTIVE)
 	if err != nil {

--- a/network_test.go
+++ b/network_test.go
@@ -36,7 +36,9 @@ func TestGetNetworkName(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := net.GetName(); err != nil {
 		t.Fatal(err)
@@ -48,7 +50,9 @@ func TestGetNetworkUUID(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := net.GetUUID()
 	if err != nil {
@@ -61,7 +65,9 @@ func TestGetNetworkUUIDString(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	_, err := net.GetUUIDString()
 	if err != nil {
@@ -74,7 +80,9 @@ func TestGetNetworkXMLDesc(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := net.GetXMLDesc(0); err != nil {
 		t.Error(err)
@@ -86,7 +94,9 @@ func TestCreateDestroyNetwork(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := net.Create(); err != nil {
 		t.Error(err)
@@ -103,7 +113,9 @@ func TestNetworkAutostart(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	as, err := net.GetAutostart()
 	if err != nil {
@@ -133,7 +145,9 @@ func TestNetworkIsActive(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := net.Create(); err != nil {
 		t.Log(err)
@@ -167,7 +181,9 @@ func TestNetworkGetBridgeName(t *testing.T) {
 	net, conn := buildTestNetwork("")
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := net.Create(); err != nil {
 		t.Error(err)
@@ -182,7 +198,11 @@ func TestNetworkGetBridgeName(t *testing.T) {
 
 func TestNetworkFree(t *testing.T) {
 	net, conn := buildTestNetwork("")
-	defer conn.CloseConnection()
+	defer func() {
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
+	}()
 	if err := net.Free(); err != nil {
 		t.Error(err)
 		return
@@ -198,7 +218,9 @@ func TestNetworkCreateXML(t *testing.T) {
 	}
 	defer func() {
 		net.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	if is_active, err := net.IsActive(); err != nil {

--- a/storage_pool_test.go
+++ b/storage_pool_test.go
@@ -30,7 +30,9 @@ func TestStoragePoolBuild(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Build(VIR_STORAGE_POOL_BUILD_NEW); err != nil {
 		t.Fatal(err)
@@ -41,7 +43,9 @@ func TestUndefineStoragePool(t *testing.T) {
 	pool, conn := buildTestStoragePool("")
 	defer func() {
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	name, err := pool.GetName()
 	if err != nil {
@@ -63,7 +67,9 @@ func TestGetStoragePoolName(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := pool.GetName(); err != nil {
 		t.Error(err)
@@ -75,7 +81,9 @@ func TestGetStoragePoolUUID(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := pool.GetUUID(); err != nil {
 		t.Error(err)
@@ -87,7 +95,9 @@ func TestGetStoragePoolUUIDString(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := pool.GetUUIDString(); err != nil {
 		t.Error(err)
@@ -99,7 +109,9 @@ func TestGetStoragePoolInfo(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := pool.GetInfo(); err != nil {
 		t.Error(err)
@@ -111,7 +123,9 @@ func TestGetStoragePoolXMLDesc(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if _, err := pool.GetXMLDesc(0); err != nil {
 		t.Error(err)
@@ -124,7 +138,9 @@ func TestStoragePoolRefresh(t *testing.T) {
 		pool.Destroy()
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -140,7 +156,9 @@ func TestCreateDestroyStoragePool(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -174,7 +192,9 @@ func TestStoragePoolAutostart(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	as, err := pool.GetAutostart()
 	if err != nil {
@@ -203,7 +223,9 @@ func TestStoragePoolIsActive(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 
 	if err := pool.Create(0); err != nil {
@@ -237,7 +259,9 @@ func TestStorageVolCreateDelete(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -259,7 +283,9 @@ func TestStorageVolCreateFromDelete(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -296,7 +322,9 @@ func TestLookupStorageVolByName(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -313,12 +341,13 @@ func TestLookupStorageVolByName(t *testing.T) {
 		vol.Delete(VIR_STORAGE_VOL_DELETE_NORMAL)
 		vol.Free()
 	}()
-	vol, err = pool.LookupStorageVolByName(defVolName)
+	vol2, err := pool.LookupStorageVolByName(defVolName)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	name, err := vol.GetName()
+	defer vol2.Free()
+	name, err := vol2.GetName()
 	if err != nil {
 		t.Error(err)
 		return

--- a/storage_volume_test.go
+++ b/storage_volume_test.go
@@ -31,7 +31,9 @@ func TestStorageVolGetInfo(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -57,7 +59,9 @@ func TestStorageVolGetKey(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -83,7 +87,9 @@ func TestStorageVolGetName(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -109,7 +115,9 @@ func TestStorageVolGetPath(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -135,7 +143,9 @@ func TestStorageVolGetXMLDesc(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -161,7 +171,9 @@ func TestPoolLookupByVolume(t *testing.T) {
 	defer func() {
 		pool.Undefine()
 		pool.Free()
-		conn.CloseConnection()
+		if res, _ := conn.CloseConnection(); res != 0 {
+			t.Errorf("CloseConnection() == %d, expected 0", res)
+		}
 	}()
 	if err := pool.Create(0); err != nil {
 		t.Error(err)
@@ -182,6 +194,7 @@ func TestPoolLookupByVolume(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer retPool.Free()
 
 	poolUUID, err := pool.GetUUIDString()
 	if err != nil {


### PR DESCRIPTION
If ConnectionClose() method doesn't return 0, this means we have either
an error, either there is still a reference to the connection by another
object (we don't have virConnectRef()). In all tests, check that return
code and ensure this is 0. Fix tests that weren't releasing all objects
correctly.