### PR TITLE
errors: don't make GetLastError() segfault when on no error condition

### DIFF
--- a/error.go
+++ b/error.go
@@ -510,6 +510,23 @@ func (err VirError) Error() string {
 		err.Code, err.Domain, err.Message)
 }
 
+var ErrNoError = VirError{
+	Code:    VIR_ERR_OK,
+	Domain:  VIR_FROM_NONE,
+	Message: "",
+	Level:   VIR_ERR_NONE,
+}
+
+func GetLastError() VirError {
+	err := C.virGetLastError()
+	if err == nil {
+		return ErrNoError
+	}
+	virErr := newError(err)
+	C.virResetError(err)
+	return virErr
+}
+
 // Callback handling for errors
 type ErrorCallback func(error VirError, opaque func())
 type errorContext struct {

--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,24 @@
 package libvirt
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetLastError(t *testing.T) {
+	_, err := NewVirConnection("invalid_transport:///default")
+	if err == nil {
+		t.Fatalf("Expected an error when creating invalid connection")
+	}
+	got := GetLastError()
+	expected := VirError{0, 0, "", 0}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected error %+v, got %+v", expected, got)
+	}
+	if got != ErrNoError {
+		t.Errorf("Expected error to be ErrNoError")
+	}
+}
 
 func TestGlobalErrorCallback(t *testing.T) {
 	var nbErrors int

--- a/libvirt.go
+++ b/libvirt.go
@@ -48,13 +48,6 @@ func NewVirConnectionReadOnly(uri string) (VirConnection, error) {
 	return obj, nil
 }
 
-func GetLastError() VirError {
-	err := C.virGetLastError()
-	virErr := newError(err)
-	C.virResetError(err)
-	return virErr
-}
-
 func (c *VirConnection) CloseConnection() (int, error) {
 	c.UnsetErrorFunc()
 	result := int(C.virConnectClose(c.ptr))


### PR DESCRIPTION
When calling `GetLastError()` twice in a row, we get a segfault because
`virGetLastError()` C function returns nil. We cannot return nil since
we don't return a pointer, but we can return a special error that means
"no error".