### PR TITLE
connection: do not unregister close callback on close

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -95,7 +95,6 @@ func NewVirConnectionReadOnly(uri string) (VirConnection, error) {
 }
 
 func (c *VirConnection) CloseConnection() (int, error) {
-	c.UnregisterCloseCallback() // Mandatory, otherwise, we are leaking the connection
 	c.UnsetErrorFunc()
 	result := int(C.virConnectClose(c.ptr))
 	if result == -1 {


### PR DESCRIPTION
This is done automatically and if the connection has been closed
unexpectedly, this will trigger an error. We ignore the error but it can
appear in the logs.