### PR TITLE
Vagrant cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ A `Vagrantfile` is included to run the integration tests:
 * `vagrant up` to provision the virtual machine
 * `vagrant ssh` to login to the virtual machine
 
-Once inside, `sudo su -`, `cd /libvirt-go` and `go test -tags integration`.
+Once inside, `sudo su -` and `go test -tags integration libvirt`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Integration tests are available where functionality isn't provided by the test d
 
 A `Vagrantfile` is included to run the integration tests:
 
-* `cd ./vagrant/{branch}` (i.e `./vagrant/master`, where you will find a `Vagrantfile` for the `master` branch)
+* `cd ./vagrant`
 * `vagrant up` to provision the virtual machine
 * `vagrant ssh` to login to the virtual machine
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -79,5 +79,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   EOF
 
   config.vm.provision :unix_reboot
-  config.vm.synced_folder "..", "/libvirt-go"
+  config.vm.synced_folder "..", "/opt/go/src/libvirt"
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@
 #
 #######################################################################################################
 
-require '../vagrant-provision-reboot-plugin'
+require './vagrant-provision-reboot-plugin'
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -79,5 +79,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   EOF
 
   config.vm.provision :unix_reboot
-  config.vm.synced_folder "../..", "/libvirt-go"
+  config.vm.synced_folder "..", "/libvirt-go"
 end


### PR DESCRIPTION
Minor cleanup for `Vagrantfile`:
- move `/libvirt-go` to `/opt/go/src/libvirt` (which is a part of `$GOPATH`) so that external binaries will be able to import it
- remove the branch name from the path to `Vagrantfile`, since only one branch is checked out at any single time, and it should probably include just one `Vagrantfile`, the correct one for the current branch