### PR TITLE
events: Return values should use golang idioms

### DIFF
--- a/events.go
+++ b/events.go
@@ -381,10 +381,8 @@ func callDomainCallbackId(goCallbackId int, c *VirConnection, d *VirDomain,
 	}
 }
 
-// BUG(vincentbernat): The returned value of DomainEventRegister,
-// DomainEventDeregister, EventRegisterDefaultImpl and
-// EventRunDefaultImpl should be an error instead of an int, for
-// coherence with other functions.
+// BUG(vincentbernat): The returned value of DomainEventRegister, should be an
+// error instead of an int, for uniformity with other functions.
 
 func (c *VirConnection) DomainEventRegister(dom VirDomain,
 	eventId int,
@@ -438,17 +436,26 @@ func (c *VirConnection) DomainEventRegister(dom VirDomain,
 	return int(ret)
 }
 
-func (c *VirConnection) DomainEventDeregister(callbackId int) int {
+func (c *VirConnection) DomainEventDeregister(callbackId int) error {
 	// Deregister the callback
-	return int(C.virConnectDomainEventDeregisterAny(c.ptr, C.int(callbackId)))
+	if i := int(C.virConnectDomainEventDeregisterAny(c.ptr, C.int(callbackId))); i != 0 {
+		return GetLastError()
+	}
+	return nil
 }
 
-func EventRegisterDefaultImpl() int {
-	return int(C.virEventRegisterDefaultImpl())
+func EventRegisterDefaultImpl() error {
+	if i := int(C.virEventRegisterDefaultImpl()); i != 0 {
+		return GetLastError()
+	}
+	return nil
 }
 
-func EventRunDefaultImpl() int {
-	return int(C.virEventRunDefaultImpl())
+func EventRunDefaultImpl() error {
+	if i := int(C.virEventRunDefaultImpl()); i != 0 {
+		return GetLastError()
+	}
+	return nil
 }
 
 func (e DomainLifecycleEvent) String() string {

--- a/events_test.go
+++ b/events_test.go
@@ -17,9 +17,8 @@ func TestDomainEventRegister(t *testing.T) {
 	conn := buildTestConnection()
 	defer func() {
 		if callbackId >= 0 {
-			ret := conn.DomainEventDeregister(callbackId)
-			if ret != 0 {
-				t.Errorf("got %d on DomainEventDeregister instead of 0", ret)
+			if err := conn.DomainEventDeregister(callbackId); err != nil {
+				t.Errorf("got `%v` on DomainEventDeregister instead of nil", err)
 			}
 		}
 		if res, _ := conn.CloseConnection(); res != 0 {
@@ -99,8 +98,8 @@ func TestDomainEventRegister(t *testing.T) {
 	goCallbackLock.Unlock()
 
 	// Deregister the event
-	if ret := conn.DomainEventDeregister(callbackId); ret < 0 {
-		t.Fatal("Event deregistration failed")
+	if err := conn.DomainEventDeregister(callbackId); err != nil {
+		t.Fatal("Event deregistration failed with: %v", err)
 	}
 	callbackId = -1 // Don't deregister twice
 


### PR DESCRIPTION
A golang lib should use idiomatic return values of error and nil instead
of int as is common in C. This updates these functions to return as
expected.